### PR TITLE
MAGICDRAW-587

### DIFF
--- a/src/main/java/gov/nasa/jpl/mbee/mdk/DgvalidationDBSwitch.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/DgvalidationDBSwitch.java
@@ -30,6 +30,7 @@ package gov.nasa.jpl.mbee.mdk;
 
 import com.nomagic.magicdraw.core.Application;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.dgvalidation.Rule;
 import gov.nasa.jpl.mbee.mdk.dgvalidation.Severity;
 import gov.nasa.jpl.mbee.mdk.dgvalidation.Suite;
@@ -70,8 +71,7 @@ public class DgvalidationDBSwitch extends DgvalidationSwitch<Object> {
     @Override
     public Object caseViolation(Violation object) {
         if (object.getElementId() != null) {
-            ValidationRuleViolation res = new ValidationRuleViolation((Element) Application.getInstance()
-                    .getProject().getElementByID(object.getElementId()), object.getComment());
+            ValidationRuleViolation res = new ValidationRuleViolation(Converters.getIdToElementConverter().apply(object.getElementId(), Application.getInstance().getProject()), object.getComment());
             return res;
         }
         return null;

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/DgviewDBSwitch.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/DgviewDBSwitch.java
@@ -32,6 +32,7 @@ import com.nomagic.magicdraw.core.Application;
 import com.nomagic.magicdraw.uml.BaseElement;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Diagram;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.dgview.*;
 import gov.nasa.jpl.mbee.mdk.dgview.util.DgviewSwitch;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
@@ -57,7 +58,8 @@ public class DgviewDBSwitch extends DgviewSwitch<DocumentElement> {
 
     private void setVe(ViewElement ve, DocumentElement de) {
         if (ve.getFromElementId() != null && !ve.getFromElementId().isEmpty()) {
-            de.setFrom((Element) Application.getInstance().getProject().getElementByID(ve.getFromElementId()));
+            de.setFrom(Converters.getIdToElementConverter()
+                    .apply(ve.getFromElementId(), Application.getInstance().getProject()));
             if (ve.getFromProperty() != null) {
                 if (ve.getFromProperty() == FromProperty.NAME) {
                     de.setFromProperty(From.NAME);
@@ -94,7 +96,8 @@ public class DgviewDBSwitch extends DgviewSwitch<DocumentElement> {
         }
         res.setDoNotShow(object.isDoNotShow());
         res.setGennew(object.isGennew());
-        BaseElement i = Application.getInstance().getProject().getElementByID(object.getDiagramId());
+        BaseElement i = Converters.getIdToElementConverter()
+                .apply(object.getDiagramId(), Application.getInstance().getProject());
         if (i instanceof Diagram) {
             res.setImage((Diagram) i);
         }
@@ -244,8 +247,8 @@ public class DgviewDBSwitch extends DgviewSwitch<DocumentElement> {
             java.util.List<PropertyEnum> rowe = new ArrayList<PropertyEnum>();
             for (ViewElement ve : tr.getChildren()) {
                 if (ve.getFromElementId() != null && !ve.getFromElementId().isEmpty()) {
-                    Element element = (Element) Application.getInstance().getProject()
-                            .getElementByID(ve.getFromElementId());
+                    Element element = Converters.getIdToElementConverter()
+                            .apply(ve.getFromElementId(), Application.getInstance().getProject());
                     row.add(element);
                     if (ve.getFromProperty() == FromProperty.DOCUMENTATION) {
                         rowe.add(PropertyEnum.DOC);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/actions/ClassToComponentRefactorWithIDAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/actions/ClassToComponentRefactorWithIDAction.java
@@ -9,6 +9,7 @@ import com.nomagic.magicdraw.uml.Refactoring;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.components.mdbasiccomponents.Component;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.sync.local.LocalSyncProjectEventListenerAdapter;
 import gov.nasa.jpl.mbee.mdk.ems.sync.local.LocalSyncTransactionCommitListener;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
@@ -45,7 +46,7 @@ public class ClassToComponentRefactorWithIDAction extends DefaultBrowserAction {
             if (!(element instanceof Class)) {
                 continue;
             }
-            String elementID = element.getID();
+            String elementID = Converters.getElementToIdConverter().apply(element);
 
 
             // Converts the element to an interface.

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/actions/ComponentToClassRefactorWithIDAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/actions/ComponentToClassRefactorWithIDAction.java
@@ -8,6 +8,7 @@ import com.nomagic.magicdraw.uml.ConvertElementInfo;
 import com.nomagic.magicdraw.uml.Refactoring;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.components.mdbasiccomponents.Component;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.sync.local.LocalSyncProjectEventListenerAdapter;
 import gov.nasa.jpl.mbee.mdk.ems.sync.local.LocalSyncTransactionCommitListener;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
@@ -45,7 +46,7 @@ public class ComponentToClassRefactorWithIDAction extends DefaultBrowserAction {
             if (!(element instanceof Component)) {
                 continue;
             }
-            String elementID = element.getID();
+            String elementID = Converters.getElementToIdConverter().apply(element);
             // Converts the element to an interface.
             ConvertElementInfo info = new ConvertElementInfo(
                     com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class.class);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/actions/MMSViewLinkAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/actions/MMSViewLinkAction.java
@@ -8,6 +8,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.*;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import gov.nasa.jpl.mbee.mdk.actions.ui.MMSViewLinkForm;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.MMSUtils;
 import gov.nasa.jpl.mbee.mdk.lib.MDUtils;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
@@ -111,9 +112,9 @@ public class MMSViewLinkAction extends MDAction {
                         label = "Documents containing " + element.getHumanName() + ":";
                         for (Element doc : documents) {
                             if (doc.equals(element)) {
-                                link = new URI(uriBasePath + "/documents/" + element.getID());
+                                link = new URI(uriBasePath + "/documents/" + Converters.getElementToIdConverter().apply(element));
                             } else {
-                                link = new URI(uriBasePath + "/documents/" + doc.getID() + "/views/" + element.getID());
+                                link = new URI(uriBasePath + "/documents/" + Converters.getElementToIdConverter().apply(doc) + "/views/" + Converters.getElementToIdConverter().apply(element));
                             }
                             JButton button = new ViewButton(doc.getHumanName(), link);
                             linkButtons.add(button);
@@ -130,7 +131,7 @@ public class MMSViewLinkAction extends MDAction {
             }else {
                 // build single link
                 try {
-                    link = new URI(uriBasePath + "/documents/" + element.getID() + "/views/" + element.getID());
+                    link = new URI(uriBasePath + "/documents/" + Converters.getElementToIdConverter().apply(element) + "/views/" + Converters.getElementToIdConverter().apply(element));
                 }
                 catch (URISyntaxException se) {
                     Application.getInstance().getGUILog().log("[ERROR] Exception occurred while generating View Editor links for " + element.getHumanName() + ". Unable to proceed.");

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/ElementFinder.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/ElementFinder.java
@@ -54,7 +54,7 @@ public class ElementFinder {
      * @param parent The top level element whose owned elements you want to select
      */
     public static List<Element> findElements(Element parent) {
-        List<Element> elements = new ArrayList<Element>();
+        List<Element> elements = new ArrayList<>();
         elements.add(parent);
         elements.addAll(parent.getOwnedElement());
         Element current;
@@ -143,7 +143,7 @@ public class ElementFinder {
                 retrievedElements.add((NamedElement) elem);
             }
         }
-        System.out.println("Found " + retrievedElements.size() + " NamedElement(s) conaining name " + elementName);
+        System.out.println("Found " + retrievedElements.size() + " NamedElement(s) containing name " + elementName);
         if (retrievedElements.size() > 0) {
             return retrievedElements;
         }
@@ -188,7 +188,7 @@ public class ElementFinder {
         if (elements == null) {
             return null;
         }
-        List<Element> retrievedElements = new ArrayList<Element>();
+        List<Element> retrievedElements = new ArrayList<>();
         for (Element elem : elements) {
             if (elem.getHumanType().equals(elementType)) {
                 retrievedElements.add(elem);
@@ -226,7 +226,7 @@ public class ElementFinder {
         if (owner == null) {
             owner = getModelRoot();
         }
-        ArrayList<Element> elements = new ArrayList<Element>();
+        ArrayList<Element> elements = new ArrayList<>();
         elements.add(owner);
         elements.addAll(owner.getOwnedElement());
         Element current;
@@ -251,17 +251,6 @@ public class ElementFinder {
      */
     public static Element getElement(String type, String name) {
         return getElement(type, name, getModelRoot());
-    }
-
-    /**
-     * Finds the indicated element based on the ID
-     *
-     * @param targetID String containing target ID in project
-     * @return
-     */
-    public static Element getElementByID(String targetID, Project project) {
-        Element target = (Element) project.getElementByID(targetID);
-        return target;
     }
 
     /**

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/MDKValidationWindow.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/MDKValidationWindow.java
@@ -33,6 +33,7 @@ import com.nomagic.magicdraw.annotation.Annotation;
 import com.nomagic.magicdraw.core.Application;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.sync.manual.ManualSyncRunner;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationRule;
@@ -206,7 +207,7 @@ public class MDKValidationWindow {
             return id;
         }
         else if (vrve != null) {
-            return vrve.getID();
+            return Converters.getElementToIdConverter().apply(vrve);
         }
         return "";
     }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/MagicDrawHelper.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/MagicDrawHelper.java
@@ -47,6 +47,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 import com.nomagic.uml2.ext.magicdraw.components.mdbasiccomponents.Component;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import com.nomagic.uml2.impl.ElementsFactory;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.ReferenceException;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 
@@ -391,7 +392,8 @@ public class MagicDrawHelper {
 
     public static Class createBlock(String name, Element owner) {
         Class newBlock = createClass(name, owner);
-        Element stereo = ElementFinder.getElementByID("_11_5EAPbeta_be00301_1147424179914_458922_958", Project.getProject(owner));
+        Element stereo = Converters.getIdToElementConverter()
+                .apply("_11_5EAPbeta_be00301_1147424179914_458922_958", Project.getProject(owner));
         if (!(stereo instanceof Stereotype)) {
             return null;
         }
@@ -462,7 +464,8 @@ public class MagicDrawHelper {
 
     public static Property createPartProperty(String name, Element owner) {
         Property newProp = createProperty(name, owner, null, null, null, null, null);
-        Element stereo = ElementFinder.getElementByID("_15_0_be00301_1199377756297_348405_2678", Project.getProject(owner));
+        Element stereo = Converters.getIdToElementConverter()
+                .apply("_15_0_be00301_1199377756297_348405_2678", Project.getProject(owner));
         if (!(stereo instanceof Stereotype)) {
             return null;
         }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/docgen/ElementReference.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/docgen/ElementReference.java
@@ -3,7 +3,8 @@ package gov.nasa.jpl.mbee.mdk.api.docgen;
 import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.uml.BaseElement;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
-import gov.nasa.jpl.mbee.mdk.api.ElementFinder;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
+
 import java.util.function.Function;
 
 /**
@@ -18,12 +19,14 @@ public abstract class ElementReference<E extends Element> implements Function<Pr
 
     @Override
     public E apply(Project project) {
-        BaseElement element = project.getElementByID(getID());
+        BaseElement element = Converters.getIdToElementConverter()
+                .apply(getID(), project);
         E e = convertInstanceOfObject(element, getElementClass());
         if (e != null) {
             return e;
         }
-        element = ElementFinder.getElementByID(getID(), project);
+        element = Converters.getIdToElementConverter()
+                .apply(getID(), project);
         e = convertInstanceOfObject(element, getElementClass());
         return e;
     }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/incubating/MDKConstants.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/incubating/MDKConstants.java
@@ -12,6 +12,7 @@ public class MDKConstants {
             SYNC_SYSML_ID_SUFFIX = "_sync",
             PRIMARY_MODEL_ID_SUFFIX = "_pm",
             APPLIED_STEREOTYPE_INSTANCE_ID_SUFFIX = "_asi",
+            VIEW_CONSTRAINT_SYSML_ID_SUFFIX = "_vc",
             ID_KEY_SUFFIX = "Id",
             IDS_KEY_SUFFIX = ID_KEY_SUFFIX + "s",
             SLOT_ID_SEPARATOR = "-slot-",

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/incubating/convert/Converters.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/incubating/convert/Converters.java
@@ -54,8 +54,7 @@ public class Converters {
                 if (id == null) {
                     return null;
                 }
-                if (id.equals(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()))
-                        || id.equals(Converters.getProjectToIdConverter().apply(project))) {
+                if (id.equals(project.getID()) || id.equals(project.getPrimaryProject().getProjectID())) {
                     return null;
                 }
                 BaseElement baseElement = project.getElementByID(id);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/api/incubating/convert/Converters.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/api/incubating/convert/Converters.java
@@ -1,7 +1,9 @@
 package gov.nasa.jpl.mbee.mdk.api.incubating.convert;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.nomagic.ci.persistence.IProject;
 import com.nomagic.magicdraw.core.Project;
+import com.nomagic.magicdraw.core.ProjectUtilities;
 import com.nomagic.magicdraw.uml.BaseElement;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.*;
 import gov.nasa.jpl.mbee.mdk.api.incubating.MDKConstants;
@@ -22,6 +24,8 @@ public class Converters {
     private static JsonToElementFunction JSON_TO_ELEMENT_CONVERTER;
     private static Function<Element, String> ELEMENT_TO_ID_CONVERTER;
     private static BiFunction<String, Project, Element> ID_TO_ELEMENT_CONVERTER;
+    private static Function<Project, String> PROJECT_TO_ID_CONVERTER;
+    private static Function<IProject, String> IPROJECT_TO_ID_CONVERTER;
 
     public static BiFunction<Element, Project, ObjectNode> getElementToJsonConverter() {
         if (ELEMENT_TO_JSON_CONVERTER == null) {
@@ -50,13 +54,14 @@ public class Converters {
                 if (id == null) {
                     return null;
                 }
-                if (id.equals(project.getPrimaryProject().getProjectID())) {
+                if (id.equals(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()))
+                        || id.equals(Converters.getProjectToIdConverter().apply(project))) {
                     return null;
                 }
                 BaseElement baseElement = project.getElementByID(id);
                 if (baseElement == null && id.endsWith(MDKConstants.PRIMARY_MODEL_ID_SUFFIX)) {
                     String projectId = id.substring(0, id.length() - MDKConstants.PRIMARY_MODEL_ID_SUFFIX.length());
-                    if (projectId.equals(project.getPrimaryProject().getProjectID())) {
+                    if (projectId.equals(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()))) {
                         return project.getPrimaryModel();
                     }
                 }
@@ -116,5 +121,35 @@ public class Converters {
             };
         }
         return ID_TO_ELEMENT_CONVERTER;
+    }
+
+    public static Function<Project, String> getProjectToIdConverter() {
+        if (PROJECT_TO_ID_CONVERTER == null) {
+            PROJECT_TO_ID_CONVERTER = (project) -> {
+                if (project == null) {
+                    return null;
+                }
+                if (!project.isRemote()) {
+                    return project.getID();
+                }
+                return ProjectUtilities.getResourceID(project.getPrimaryProject().getLocationURI());
+            };
+        }
+        return PROJECT_TO_ID_CONVERTER;
+    }
+
+    public static Function<IProject, String> getIProjectToIdConverter() {
+        if (IPROJECT_TO_ID_CONVERTER == null) {
+            IPROJECT_TO_ID_CONVERTER = (iProject) -> {
+                if (iProject == null) {
+                    return null;
+                }
+                if (iProject.getLocationURI().isFile()) {
+                    return iProject.getProjectID();
+                }
+                return ProjectUtilities.getResourceID(iProject.getLocationURI());
+            };
+        }
+        return IPROJECT_TO_ID_CONVERTER;
     }
 }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/constraint/BasicConstraint.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/constraint/BasicConstraint.java
@@ -33,6 +33,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Comment;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import gov.nasa.jpl.mbee.mdk.DocGen3Profile;
 import gov.nasa.jpl.mbee.mdk.DocGenUtils;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.*;
 import gov.nasa.jpl.mbee.mdk.ocl.OclEvaluator;
 
@@ -633,7 +634,7 @@ public class BasicConstraint implements Constraint {
     }
 
     protected static String toString(Element e, boolean showElementId) {
-        return Utils.getName(e) + (showElementId ? "[" + e.getID() + "]" : "");
+        return Utils.getName(e) + (showElementId ? "[" + Converters.getElementToIdConverter().apply(e) + "]" : "");
     }
 
     protected static String toString(Collection<? extends Object> coll, boolean showElementId) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/table/EditableTable.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/table/EditableTable.java
@@ -40,6 +40,7 @@ import com.nomagic.magicdraw.uml2.util.UML2ModelUtil;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Property;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 
 import javax.swing.*;
@@ -271,7 +272,7 @@ public class EditableTable extends JDialog {
                     }
 
                     if (e != null) {
-                        if (el instanceof Element && ((Element) el).getID().equals(props[c])) {
+                        if (el instanceof Element && Converters.getElementToIdConverter().apply((Element) el).equals(props[c])) {
                             if (e.isEditable()) {
                                 try {
                                     String curValue = (String) ntable.getValueAt(row, col);
@@ -443,7 +444,7 @@ public class EditableTable extends JDialog {
                 for (int j = 0; j < cols; j++) {
                     Object mdo = m.get(i).get(j);
                     if (mdo != null && mdo instanceof Element) {
-                        s.add(((Element) mdo).getID());
+                        s.add(Converters.getElementToIdConverter().apply((Element) mdo));
                     }
                     else {
                         s.add("");

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/table/EditableTable.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/table/EditableTable.java
@@ -257,7 +257,8 @@ public class EditableTable extends JDialog {
                         continue;
                     }
                     PropertyEnum whatToChange = null;
-                    BaseElement e = prj.getElementByID(props[c]);
+                    BaseElement e = Converters.getIdToElementConverter()
+                            .apply(props[c], prj);
                     String value = props[c + 1];
                     if (what != null && what.size() > row && what.get(row).size() > col) {
                         whatToChange = what.get(row).get(col);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/validation/ConstraintValidationRule.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/validation/ConstraintValidationRule.java
@@ -39,6 +39,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdinterfaces.Interface;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.*;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 import gov.nasa.jpl.mbee.mdk.DocGen3Profile;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.constraint.BasicConstraint;
 import gov.nasa.jpl.mbee.mdk.constraint.BasicConstraint.Type;
 import gov.nasa.jpl.mbee.mdk.generator.DocumentValidator;
@@ -153,7 +154,8 @@ public class ConstraintValidationRule extends ValidationRule implements ElementV
         // Collection< String > ids = paramProject.getAllIDS();
         //
         // for ( String id : ids ) {
-        // BaseElement elem = paramProject.getElementByID( id );
+        // BaseElement elem = Converters.getIdToElementConverter()
+        //         .apply(id, paramProject);
 
         for (Element elemt : paramCollection) {
             if (elemt == null) {
@@ -310,7 +312,7 @@ public class ConstraintValidationRule extends ValidationRule implements ElementV
             }
         }
         Project project = Utils.getProject();
-        Constraint cons = (Constraint) project.getElementByID("_17_0_2_2_f4a035d_1360957024690_702520_27755");
+        Constraint cons = Utils.getWarningConstraint();
         result = Utils.getAnnotations(this, project, cons);
         annotations = result;
 

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/emf/EMFExporter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/emf/EMFExporter.java
@@ -33,11 +33,13 @@ package gov.nasa.jpl.mbee.mdk.emf;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.*;
 import com.nomagic.ci.persistence.IAttachedProject;
+import com.nomagic.ci.persistence.IProject;
 import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.core.ProjectUtilities;
 import com.nomagic.magicdraw.esi.EsiUtils;
 import com.nomagic.magicdraw.esi.EsiUtilsInternal;
 import com.nomagic.magicdraw.foundation.MDObject;
+import com.nomagic.magicdraw.uml.BaseElement;
 import com.nomagic.uml2.ext.jmi.helpers.ModelHelper;
 import com.nomagic.uml2.ext.jmi.helpers.StereotypesHelper;
 import com.nomagic.uml2.ext.magicdraw.auxiliaryconstructs.mdmodels.Model;
@@ -120,15 +122,6 @@ public class EMFExporter implements BiFunction<Element, Project, ObjectNode> {
         if (eObject == null) {
             return null;
         }
-        Project project;
-        if (eObject instanceof Model && (project = Project.getProject((Model) eObject)).getPrimaryModel() == eObject) {
-            if (project.isRemote()) {
-                return ProjectUtilities.getResourceID(project.getPrimaryProject().getProjectDescriptor().getLocationUri()) + MDKConstants.PRIMARY_MODEL_ID_SUFFIX;
-            }
-            else {
-                return project.getPrimaryProject().getProjectID() + MDKConstants.PRIMARY_MODEL_ID_SUFFIX;
-            }
-        }
         if (eObject instanceof InstanceSpecification && ((InstanceSpecification) eObject).getStereotypedElement() != null) {
             return getEID(((InstanceSpecification) eObject).getStereotypedElement()) + MDKConstants.APPLIED_STEREOTYPE_INSTANCE_ID_SUFFIX;
         }
@@ -145,8 +138,21 @@ public class EMFExporter implements BiFunction<Element, Project, ObjectNode> {
                 return getEID(slot.getOwner()) + MDKConstants.SLOT_ID_SEPARATOR + getEID(slot.getDefiningFeature());
             }
         }
-        if (eObject instanceof MDObject) {
-            return ((MDObject) eObject).getID();
+        if (eObject instanceof Element) {
+            Element element = (Element) eObject;
+            Project project = Project.getProject(element);
+            if (eObject instanceof Model && project.getPrimaryModel() == element) {
+                return Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) + MDKConstants.PRIMARY_MODEL_ID_SUFFIX;
+            }
+            IProject iProject = ProjectUtilities.getAttachedProject(element);
+            // eObject is in local primary model OR TWC online copy of a local mount
+            if ((iProject == null && !project.isRemote())
+                    || (iProject != null && iProject.getLocationURI().isFile())) {
+                return element.getLocalID();
+            }
+            // eObject is in TWC primary model OR online mount
+            // NOTE: assumes that project.getLocationURI().isFile() === !project.isRemote()
+            return element.getID();
         }
         return EcoreUtil.getID(eObject);
     }
@@ -226,8 +232,8 @@ public class EMFExporter implements BiFunction<Element, Project, ObjectNode> {
                 }
         ),
         SYNC(
-                (element, project, objectNode) -> element == null || element.getID().endsWith(MDKConstants.SYNC_SYSML_ID_SUFFIX) ||
-                        element.getOwner() != null && element.getOwner().getID().endsWith(MDKConstants.SYNC_SYSML_ID_SUFFIX) ? null : objectNode
+                (element, project, objectNode) -> element == null || Converters.getElementToIdConverter().apply(element).endsWith(MDKConstants.SYNC_SYSML_ID_SUFFIX) ||
+                        element.getOwner() != null && Converters.getElementToIdConverter().apply(element.getOwner()).endsWith(MDKConstants.SYNC_SYSML_ID_SUFFIX) ? null : objectNode
         ),
         ATTACHED_PROJECT(
                 (element, project, objectNode) -> ProjectUtilities.isElementInAttachedProject(element) && !(element instanceof Model) ? null : objectNode
@@ -270,7 +276,7 @@ public class EMFExporter implements BiFunction<Element, Project, ObjectNode> {
                         return null;
                     }
                     objectNode.put(MDKConstants.MOUNTED_ELEMENT_ID_KEY, Converters.getElementToIdConverter().apply(project.getPrimaryModel()));
-                    objectNode.put(MDKConstants.MOUNTED_ELEMENT_PROJECT_ID_KEY, attachedProject.getPrimaryProject().getProjectID());
+                    objectNode.put(MDKConstants.MOUNTED_ELEMENT_PROJECT_ID_KEY, Converters.getIProjectToIdConverter().apply(attachedProject.getPrimaryProject()));
                     objectNode.put(MDKConstants.REF_ID, EsiUtilsInternal.getCurrentBranch(attachedProject).getName());
                     objectNode.put("teamworkCloudVersion", ProjectUtilities.versionToInt(ProjectUtilities.getVersion(attachedProject).getName()));
                     //objectNode.put("_uri", ProjectDescriptorsFactory.createRemoteProjectDescriptorWithActualVersion(attachedProject.getProjectDescriptor()));
@@ -401,7 +407,7 @@ public class EMFExporter implements BiFunction<Element, Project, ObjectNode> {
                     }*/
                     //UNCHECKED_E_STRUCTURAL_FEATURE_FUNCTION.apply(element, project, UMLPackage.Literals.ELEMENT__OWNER, objectNode);
                     // safest way to prevent circular references, like with ValueSpecifications
-                    objectNode.put(MDKConstants.OWNER_ID_KEY, element instanceof Model ? project.getPrimaryProject().getProjectID() : getEID(owner));
+                    objectNode.put(MDKConstants.OWNER_ID_KEY, element instanceof Model ? Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) : getEID(owner));
                     return objectNode;
                 }
         ),

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/emf/EMFImporter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/emf/EMFImporter.java
@@ -413,7 +413,7 @@ public class EMFImporter implements JsonToElementFunction {
                         }
                         if (element instanceof Package
                                 && (jsonNode = objectNode.get(MDKConstants.SYSML_ID_KEY)) != null && jsonNode.isTextual() && jsonNode.asText().startsWith("holding_bin")
-                                && (jsonNode = objectNode.get(MDKConstants.OWNER_ID_KEY)) != null && jsonNode.isTextual() && jsonNode.asText().equals(project.getPrimaryProject().getProjectID())) {
+                                && (jsonNode = objectNode.get(MDKConstants.OWNER_ID_KEY)) != null && jsonNode.isTextual() && jsonNode.asText().equals(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()))) {
                             ((Package) element).setOwningPackage(project.getPrimaryModel());
                             return element;
                         }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/MMSUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/MMSUtils.java
@@ -172,8 +172,8 @@ public class MMSUtils {
         if (depth > 0) {
             requestUri.setParameter("depth", java.lang.Integer.toString(depth));
         }
-        else {
-            requestUri.setParameter("recurse", java.lang.Boolean.toString(recurse));
+        else if (recurse) {
+            requestUri.setParameter("depth", java.lang.Integer.toString(9999));
         }
 
         // do request in cancellable thread
@@ -669,7 +669,7 @@ public class MMSUtils {
         if (projectUri == null) {
             return null;
         }
-        String projectId = project.getPrimaryProject().getProjectID();
+        String projectId = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject());
         projectUri.setPath(projectUri.getPath() + "/projects/" + projectId);
         return projectUri;
     }
@@ -715,21 +715,16 @@ public class MMSUtils {
     }
 
     public static ObjectNode getProjectObjectNode(Project project) {
-        String categoryId = null;
-        String sysmlId;
-        if (project.isRemote()) {
-            sysmlId = ProjectUtilities.getResourceID(project.getPrimaryProject().getLocationURI()).toString();
-            // TODO @DONBOT enable for 18.5GA when the method is usable, remove the branch assignment placeholder
-//            categoryId = EsiUtils.getCategoryID(resourceId);
-        }
-        else {
-            sysmlId = project.getPrimaryProject().getProjectID();
-        }
-        return getProjectObjectNode(project.getPrimaryProject().getName(), sysmlId, categoryId);
+        return getProjectObjectNode(project.getPrimaryProject());
     }
 
-    public static ObjectNode getProjectObjectNode(IProject project) {
-        return getProjectObjectNode(project.getName(), project.getProjectID(), null);
+    public static ObjectNode getProjectObjectNode(IProject iProject) {
+        String categoryId = null;
+        if (ProjectUtilities.getProject(iProject).getPrimaryProject() == iProject) {
+            // TODO @donbot enable full version below after 18.5GA
+//            String categoryId = (project.isRemote() ? EsiUtils.getCategoryID(resourceId) : "local" );
+        }
+        return getProjectObjectNode(iProject.getName(), Converters.getIProjectToIdConverter().apply(iProject), categoryId);
     }
 
     private static ObjectNode getProjectObjectNode(String name, String projectId, String categoryId) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/MMSUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/MMSUtils.java
@@ -173,7 +173,7 @@ public class MMSUtils {
             requestUri.setParameter("depth", java.lang.Integer.toString(depth));
         }
         else if (recurse) {
-            requestUri.setParameter("depth", java.lang.Integer.toString(9999));
+            requestUri.setParameter("recurse", java.lang.Boolean.toString(recurse));
         }
 
         // do request in cancellable thread
@@ -306,10 +306,11 @@ public class MMSUtils {
             throws IOException, ServerException {
         // if not bypassing ticket check and ticket invalid, attempt to get new login credentials
         if (!bypassTicketCheck && !TicketUtils.isTicketValid()) {
-            // if new login credentials fail, logout and terminal jms sync;
+            // if new login credentials fail, logout and terminate jms sync;
             // 403 exception should already be thrown by failed credentials acquisition attempt
             if (!TicketUtils.loginToMMS()) {
                 new EMSLogoutAction().logoutAction();
+                throw new ServerException("Invalid credentials", 403);
             }
         }
         HttpEntityEnclosingRequest httpEntityEnclosingRequest = null;

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/CreateMMSWorkspaceAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/CreateMMSWorkspaceAction.java
@@ -102,7 +102,7 @@ public class CreateMMSWorkspaceAction extends RuleViolationAction implements Ann
         wsIdMapping.put(id, name);
         ProjectDescriptor newBranch = branchDescriptors.get(name);
         // TODO Test this version stuff @donbot
-        int version = MDUtils.getLatestEsiVersion(newBranch);
+        long version = MDUtils.getLatestEsiVersion(newBranch);
         try {
             CreateMMSWorkspaceAction.initializeWorkspace(project, id);
         } catch (IOException | URISyntaxException | ServerException e1) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/DetailedSyncStatusAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/DetailedSyncStatusAction.java
@@ -3,7 +3,6 @@ package gov.nasa.jpl.mbee.mdk.ems.actions;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nomagic.magicdraw.core.Application;
 import com.nomagic.magicdraw.core.Project;
-import com.nomagic.magicdraw.uml.BaseElement;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import gov.nasa.jpl.mbee.mdk.actions.LockAction;
 import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
@@ -81,15 +80,7 @@ public class DetailedSyncStatusAction extends SRAction {
                 for (Changelog.ChangeType changeType : Changelog.ChangeType.values()) {
                     for (String key : changelog.get(changeType).keySet()) {
                         String comment = "[" + syncElementType.name() + "] [" + changeType.name() + "]";
-                        BaseElement baseElement = Converters.getIdToElementConverter()
-                                .apply(key, project);
-                        Element element = null;
-                        if (baseElement instanceof Element) {
-                            element = (Element) baseElement;
-                        }
-                        else {
-                            comment += " " + key;
-                        }
+                        Element element = Converters.getIdToElementConverter().apply(key, project);
                         validationRuleMap.get(syncElementType).get(changeType).addViolation(new ValidationRuleViolation(element, comment));
                     }
                 }
@@ -108,9 +99,8 @@ public class DetailedSyncStatusAction extends SRAction {
             if (jmsMessageListener != null) {
                 ValidationRule validationRule = validationRuleMap.get(SyncElement.Type.MMS).get(changeType);
                 for (Map.Entry<String, ObjectNode> entry : jmsMessageListener.getInMemoryJMSChangelog().get(changeType).entrySet()) {
-                    BaseElement baseElement = Converters.getIdToElementConverter()
-                            .apply(entry.getKey(), project);
-                    validationRule.addViolation(new ValidationRuleViolation(baseElement instanceof Element ? (Element) baseElement : null, "[" + SyncElement.Type.MMS.name() + "] [" + changeType.name() + "]" + (baseElement instanceof Element ? "" : " " + entry.getKey())));
+                    Element element = Converters.getIdToElementConverter().apply(entry.getKey(), project);
+                    validationRule.addViolation(new ValidationRuleViolation(element, "[" + SyncElement.Type.MMS.name() + "] [" + changeType.name() + "]"));
                 }
             }
         }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/DetailedSyncStatusAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/DetailedSyncStatusAction.java
@@ -6,6 +6,7 @@ import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.uml.BaseElement;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import gov.nasa.jpl.mbee.mdk.actions.LockAction;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationRule;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationRuleViolation;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationSuite;
@@ -80,7 +81,8 @@ public class DetailedSyncStatusAction extends SRAction {
                 for (Changelog.ChangeType changeType : Changelog.ChangeType.values()) {
                     for (String key : changelog.get(changeType).keySet()) {
                         String comment = "[" + syncElementType.name() + "] [" + changeType.name() + "]";
-                        BaseElement baseElement = project.getElementByID(key);
+                        BaseElement baseElement = Converters.getIdToElementConverter()
+                                .apply(key, project);
                         Element element = null;
                         if (baseElement instanceof Element) {
                             element = (Element) baseElement;
@@ -106,7 +108,8 @@ public class DetailedSyncStatusAction extends SRAction {
             if (jmsMessageListener != null) {
                 ValidationRule validationRule = validationRuleMap.get(SyncElement.Type.MMS).get(changeType);
                 for (Map.Entry<String, ObjectNode> entry : jmsMessageListener.getInMemoryJMSChangelog().get(changeType).entrySet()) {
-                    BaseElement baseElement = project.getElementByID(entry.getKey());
+                    BaseElement baseElement = Converters.getIdToElementConverter()
+                            .apply(entry.getKey(), project);
                     validationRule.addViolation(new ValidationRuleViolation(baseElement instanceof Element ? (Element) baseElement : null, "[" + SyncElement.Type.MMS.name() + "] [" + changeType.name() + "]" + (baseElement instanceof Element ? "" : " " + entry.getKey())));
                 }
             }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/ExportImage.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/ExportImage.java
@@ -34,6 +34,7 @@ import com.nomagic.magicdraw.annotation.Annotation;
 import com.nomagic.magicdraw.annotation.AnnotationAction;
 import com.nomagic.magicdraw.core.Project;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.MMSUtils;
 import gov.nasa.jpl.mbee.mdk.ems.sync.queue.OutputQueue;
 import gov.nasa.jpl.mbee.mdk.ems.sync.queue.Request;
@@ -107,7 +108,7 @@ public class ExportImage extends RuleViolationAction implements AnnotationAction
     public void execute(Collection<Annotation> annos) {
         for (Annotation anno : annos) {
             Element e = (Element) anno.getTarget();
-            String key = e.getID();
+            String key = Converters.getElementToIdConverter().apply(e);
             postImage(Project.getProject(e), key, images);
         }
         Utils.guilog("[INFO] Requests are added to queue.");
@@ -116,7 +117,7 @@ public class ExportImage extends RuleViolationAction implements AnnotationAction
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        String key = element.getID();
+        String key = Converters.getElementToIdConverter().apply(element);
         if (postImage(Project.getProject(element), key, images)) {
             Utils.guilog("[INFO] Request is added to queue.");
         }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/GenerateViewPresentationAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/actions/GenerateViewPresentationAction.java
@@ -7,6 +7,7 @@ import com.nomagic.uml2.ext.jmi.helpers.StereotypesHelper;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.generator.ViewPresentationGenerator;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationSuite;
@@ -47,7 +48,7 @@ public class GenerateViewPresentationAction extends MDAction {
         while (!queuedElements.isEmpty()) {
             Element element = queuedElements.remove();
             if (processedElements.contains(element)) {
-                Application.getInstance().getGUILog().log("Detected duplicate element reference. Skipping generation for " + element.getID() + ".");
+                Application.getInstance().getGUILog().log("Detected duplicate element reference. Skipping generation for " + Converters.getElementToIdConverter().apply(element) + ".");
                 continue;
             }
             if (StereotypesHelper.hasStereotypeOrDerived(element, viewStereotype)) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/jms/JMSUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/jms/JMSUtils.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nomagic.magicdraw.core.Application;
 import com.nomagic.magicdraw.core.Project;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.MMSUtils;
 import gov.nasa.jpl.mbee.mdk.ems.ServerException;
 
@@ -198,7 +199,7 @@ public class JMSUtils {
     }
 
     public static void initializeDurableQueue(Project project, String workspace) {
-        String projectId = project.getPrimaryProject().getProjectID();
+        String projectId = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject());
         Connection connection = null;
         Session session = null;
         MessageConsumer consumer = null;

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/coordinated/CoordinatedSyncProjectEventListenerAdapter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/coordinated/CoordinatedSyncProjectEventListenerAdapter.java
@@ -7,6 +7,7 @@ import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.core.project.ProjectEventListenerAdapter;
 import com.nomagic.ui.ProgressStatusRunner;
 import com.nomagic.uml2.ext.jmi.helpers.StereotypesHelper;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.actions.EMSLoginAction;
 import gov.nasa.jpl.mbee.mdk.ems.jms.JMSUtils;
 import gov.nasa.jpl.mbee.mdk.ems.sync.delta.DeltaSyncRunner;
@@ -37,7 +38,7 @@ public class CoordinatedSyncProjectEventListenerAdapter extends ProjectEventList
         if (coordinatedSyncProjectMapping.isDisabled()) {
             return;
         }
-        projectMappings.remove(project.getPrimaryProject().getProjectID());
+        projectMappings.remove(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
     }
 
     @Override
@@ -100,7 +101,7 @@ public class CoordinatedSyncProjectEventListenerAdapter extends ProjectEventList
             teamworkCommittedMessage.set("synced", SyncElements.buildJson(deltaSyncRunner.getSuccessfulJmsChangelog()));
             try {
                 TextMessage successfulTextMessage = jmsSyncProjectMapping.getSession().createTextMessage(JacksonUtils.getObjectMapper().writeValueAsString(teamworkCommittedMessage));
-                successfulTextMessage.setStringProperty(JMSUtils.MSG_SELECTOR_PROJECT_ID, project.getPrimaryProject().getProjectID());
+                successfulTextMessage.setStringProperty(JMSUtils.MSG_SELECTOR_PROJECT_ID, Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
                 successfulTextMessage.setStringProperty(JMSUtils.MSG_SELECTOR_WORKSPACE_ID, MDUtils.getWorkspace(project) + "_mdk");
                 jmsSyncProjectMapping.getMessageProducer().send(successfulTextMessage);
                 int syncCount = deltaSyncRunner.getSuccessfulJmsChangelog().flattenedSize();
@@ -113,10 +114,10 @@ public class CoordinatedSyncProjectEventListenerAdapter extends ProjectEventList
     }
 
     public static CoordinatedSyncProjectMapping getProjectMapping(Project project) {
-        CoordinatedSyncProjectMapping coordinatedSyncProjectMapping = projectMappings.get(MDUtils.getProjectID(project));
+        CoordinatedSyncProjectMapping coordinatedSyncProjectMapping = projectMappings.get(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
         if (coordinatedSyncProjectMapping == null) {
-            projectMappings.put(MDUtils.getProjectID(project), coordinatedSyncProjectMapping = new CoordinatedSyncProjectMapping());
-            projectMappings.get(MDUtils.getProjectID(project)).setDisabled(!project.isRemote());
+            projectMappings.put(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()), coordinatedSyncProjectMapping = new CoordinatedSyncProjectMapping());
+            projectMappings.get(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject())).setDisabled(!project.isRemote());
         }
         return coordinatedSyncProjectMapping;
     }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/delta/SyncElements.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/delta/SyncElements.java
@@ -34,7 +34,7 @@ public class SyncElements {
     private static final DateFormat NAME_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH.mm.ss.SSSZ");
 
     private static String getSyncPackageID(Project project) {
-        return project.getPrimaryProject().getProjectID() + MDKConstants.SYNC_SYSML_ID_SUFFIX;
+        return Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) + MDKConstants.SYNC_SYSML_ID_SUFFIX;
     }
 
     public static Package getSyncPackage(Project project) {
@@ -215,7 +215,7 @@ public class SyncElements {
         if (!ProjectUtilities.isFromEsiServer(project.getPrimaryProject())) {
             return Collections.emptyList();
         }
-        String folderId = project.getPrimaryProject().getProjectID() + "_sync";
+        String folderId = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) + "_sync";
         Element folder = Converters.getIdToElementConverter().apply(folderId, project);
         if (folder == null) {
             return Collections.emptyList();

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/delta/SyncElements.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/delta/SyncElements.java
@@ -215,7 +215,7 @@ public class SyncElements {
         if (!ProjectUtilities.isFromEsiServer(project.getPrimaryProject())) {
             return Collections.emptyList();
         }
-        String folderId = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) + "_sync";
+        String folderId = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) + MDKConstants.SYNC_SYSML_ID_SUFFIX;
         Element folder = Converters.getIdToElementConverter().apply(folderId, project);
         if (folder == null) {
             return Collections.emptyList();

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/jms/JMSMessageListener.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/jms/JMSMessageListener.java
@@ -7,6 +7,7 @@ import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.openapi.uml.ReadOnlyElementException;
 import gov.nasa.jpl.mbee.mdk.MMSSyncPlugin;
 import gov.nasa.jpl.mbee.mdk.api.incubating.MDKConstants;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.emf.EMFImporter;
 import gov.nasa.jpl.mbee.mdk.ems.ImportException;
 import gov.nasa.jpl.mbee.mdk.ems.actions.EMSLogoutAction;
@@ -89,7 +90,7 @@ public class JMSMessageListener implements MessageListener, ExceptionListener {
             return;
         }
         if (MDKOptionsGroup.getMDKOptions().isLogJson()) {
-            System.out.println("MMS TextMessage for " + project.getPrimaryProject().getProjectID() + " -" + System.lineSeparator() + text);
+            System.out.println("MMS TextMessage for " + Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()) + " -" + System.lineSeparator() + text);
         }
         JsonNode messageJsonNode;
         try {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/jms/JMSSyncProjectEventListenerAdapter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/jms/JMSSyncProjectEventListenerAdapter.java
@@ -6,6 +6,7 @@ import com.nomagic.magicdraw.core.ProjectUtilities;
 import com.nomagic.magicdraw.core.project.ProjectEventListenerAdapter;
 import com.nomagic.magicdraw.esi.EsiUtils;
 import com.nomagic.uml2.ext.jmi.helpers.StereotypesHelper;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.ServerException;
 import gov.nasa.jpl.mbee.mdk.ems.actions.EMSLoginAction;
 import gov.nasa.jpl.mbee.mdk.ems.jms.JMSUtils;
@@ -97,11 +98,11 @@ public class JMSSyncProjectEventListenerAdapter extends ProjectEventListenerAdap
         } catch (JMSException e) {
             e.printStackTrace();
         }
-        projectMappings.remove(project.getPrimaryProject().getProjectID());
+        projectMappings.remove(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
     }
 
     public boolean initDurable(Project project) {
-        String projectID = project.getPrimaryProject().getProjectID();
+        String projectID = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject());
         String workspaceID = MDUtils.getWorkspace(project);
 
         // verify logged in to appropriate places
@@ -207,9 +208,9 @@ public class JMSSyncProjectEventListenerAdapter extends ProjectEventListenerAdap
     }
 
     public static JMSSyncProjectMapping getProjectMapping(Project project) {
-        JMSSyncProjectMapping JMSSyncProjectMapping = projectMappings.get(project.getPrimaryProject().getProjectID());
+        JMSSyncProjectMapping JMSSyncProjectMapping = projectMappings.get(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
         if (JMSSyncProjectMapping == null) {
-            projectMappings.put(project.getPrimaryProject().getProjectID(), JMSSyncProjectMapping = new JMSSyncProjectMapping(project));
+            projectMappings.put(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()), JMSSyncProjectMapping = new JMSSyncProjectMapping(project));
         }
         return JMSSyncProjectMapping;
     }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/local/LocalSyncProjectEventListenerAdapter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/local/LocalSyncProjectEventListenerAdapter.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.mbee.mdk.ems.sync.local;
 import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.core.project.ProjectEventListenerAdapter;
 import com.nomagic.magicdraw.uml.transaction.MDTransactionManager;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,9 +60,9 @@ public class LocalSyncProjectEventListenerAdapter extends ProjectEventListenerAd
     }
 
     public static LocalSyncProjectMapping getProjectMapping(Project project) {
-        LocalSyncProjectMapping localSyncProjectMapping = projectMappings.get(project.getPrimaryProject().getProjectID());
+        LocalSyncProjectMapping localSyncProjectMapping = projectMappings.get(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
         if (localSyncProjectMapping == null) {
-            projectMappings.put(project.getPrimaryProject().getProjectID(), localSyncProjectMapping = new LocalSyncProjectMapping(project));
+            projectMappings.put(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()), localSyncProjectMapping = new LocalSyncProjectMapping(project));
         }
         return localSyncProjectMapping;
     }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/manual/ManualSyncRunner.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/sync/manual/ManualSyncRunner.java
@@ -148,7 +148,7 @@ public class ManualSyncRunner implements RunnableWithProgress {
                 }
 
                 if (depth > 0 || recurse) {
-                    String holdingBinId = "holding_bin_" + project.getPrimaryProject().getProjectID();
+                    String holdingBinId = "holding_bin_" + Converters.getIProjectToIdConverter().apply(project.getPrimaryProject());
                     boolean found = false;
                     // check to see if the holding bin was returned
                     for (ObjectNode elem : serverElements) {
@@ -180,7 +180,7 @@ public class ManualSyncRunner implements RunnableWithProgress {
         if (requestUri == null) {
             return false;
         }
-        requestUri.setPath(requestUri.getPath() + "/" + project.getPrimaryProject().getProjectID());
+        requestUri.setPath(requestUri.getPath() + "/" + Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()));
 
         // do request for site element
         ObjectNode response = JacksonUtils.getObjectMapper().createObjectNode();

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/validation/ElementValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/validation/ElementValidator.java
@@ -142,7 +142,7 @@ public class ElementValidator implements RunnableWithProgress {
                 validationRuleViolation.addAction(copyActionsCategory);
                 copyActionsCategory.addAction(new ClipboardAction("ID", id));
                 if (clientElementElement != null) {
-                    copyActionsCategory.addAction(new ClipboardAction("Element Hyperlink", "mdel://" + clientElementElement.getID()));
+                    copyActionsCategory.addAction(new ClipboardAction("Element Hyperlink", "mdel://" + Converters.getElementToIdConverter().apply(clientElementElement)));
                 }
                 if (clientElementObjectNode != null) {
                     try {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/validation/ElementValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/validation/ElementValidator.java
@@ -142,7 +142,7 @@ public class ElementValidator implements RunnableWithProgress {
                 validationRuleViolation.addAction(copyActionsCategory);
                 copyActionsCategory.addAction(new ClipboardAction("ID", id));
                 if (clientElementElement != null) {
-                    copyActionsCategory.addAction(new ClipboardAction("Element Hyperlink", "mdel://" + Converters.getElementToIdConverter().apply(clientElementElement)));
+                    copyActionsCategory.addAction(new ClipboardAction("Element Hyperlink", "mdel://" + clientElementElement.getID()));
                 }
                 if (clientElementObjectNode != null) {
                     try {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ems/validation/ModuleValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ems/validation/ModuleValidator.java
@@ -10,6 +10,7 @@ import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.core.ProjectUtilities;
 import com.nomagic.task.ProgressStatus;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationRule;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationRuleViolation;
 import gov.nasa.jpl.mbee.mdk.docgen.validation.ValidationSuite;
@@ -95,7 +96,7 @@ public class ModuleValidator {
                 if (projectUriBuilder == null) {
                     continue;
                 }
-                projectUriBuilder.setPath(projectUriBuilder.getPath() + "/projects/" + module.getProjectID());
+                projectUriBuilder.setPath(projectUriBuilder.getPath() + "/projects/" + Converters.getIProjectToIdConverter().apply(module));
                 ObjectNode responseObjectNode;
                 try {
                     responseObjectNode = MMSUtils.sendMMSRequest(MMSUtils.buildRequest(MMSUtils.HttpRequestType.GET, projectUriBuilder));

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/generator/DocumentGenerator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/generator/DocumentGenerator.java
@@ -45,6 +45,7 @@ import com.nomagic.uml2.ext.magicdraw.commonbehaviors.mdbasicbehaviors.Behavior;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import gov.nasa.jpl.mbee.mdk.DocGen3Profile;
 import gov.nasa.jpl.mbee.mdk.MDKPlugin;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.*;
 import gov.nasa.jpl.mbee.mdk.docgen.docbook.From;
 import gov.nasa.jpl.mbee.mdk.model.*;
@@ -310,7 +311,7 @@ public class DocumentGenerator {
             }
         }
         viewSection.setDgElement(view);
-        viewSection.setId(view.getID());
+        viewSection.setId(Converters.getElementToIdConverter().apply(view));
         viewSection.setTitle(((NamedElement) view).getName());
         return viewSection;
     }
@@ -332,7 +333,7 @@ public class DocumentGenerator {
         if (a == null || parent == null) {
             return null;
         }
-        Debug.outln("parseActivityOrStructuredNode( " + a.getHumanName() + ", " + a.getID() + ", "
+        Debug.outln("parseActivityOrStructuredNode( " + a.getHumanName() + ", " + Converters.getElementToIdConverter().apply(a) + ", "
                 + parent.getStringIfEmpty() + ")");
         InitialNode in = GeneratorUtils.findInitialNode(a);
         if (in == null) {
@@ -346,7 +347,7 @@ public class DocumentGenerator {
         while (outs != null && outs.size() == 1) {
             parseResults = null;
             ActivityNode next = outs.iterator().next().getTarget();
-            Debug.outln("next = " + next.getHumanName() + ", " + next.getID());
+            Debug.outln("next = " + next.getHumanName() + ", " + Converters.getElementToIdConverter().apply(next));
             next2 = null;
             boolean evaluatedConstraintsForNext = false;
             if (next instanceof CallBehaviorAction
@@ -481,7 +482,7 @@ public class DocumentGenerator {
             }
             outs = next2.getOutgoing();
             Debug.outln("outs = " + MoreToString.Helper.toLongString(outs) + " for next2 = "
-                    + next2.getHumanName() + ", " + next2.getID());
+                    + next2.getHumanName() + ", " + Converters.getElementToIdConverter().apply(next2));
         }
         while (pushed > 0) {
             this.context.popTargets();

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/generator/DocumentValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/generator/DocumentValidator.java
@@ -46,6 +46,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 import com.nomagic.uml2.ext.magicdraw.commonbehaviors.mdbasicbehaviors.Behavior;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import gov.nasa.jpl.mbee.mdk.DocGen3Profile;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.constraint.BasicConstraint;
 import gov.nasa.jpl.mbee.mdk.constraint.Constraint;
 import gov.nasa.jpl.mbee.mdk.lib.Debug;
@@ -806,7 +807,7 @@ public class DocumentValidator {
             result = OclEvaluator.evaluateQuery(context, expression);
         } catch (ParserException e) {
             if (violationIfInconsistent) {
-                String id = context instanceof Element ? ((Element) context).getID() : context.toString();
+                String id = context instanceof Element ? Converters.getElementToIdConverter().apply((Element) context) : context.toString();
                 String errorMessage = e.getLocalizedMessage() + " for OCL query \"" + expression + "\" on "
                         + Utils.getName(context) + (showElementIds ? "[" + id + "]" : "");
                 if (rule != null && context instanceof Element) {
@@ -934,7 +935,7 @@ public class DocumentValidator {
         List<Constraint> constraints = getConstraints(constrainedObject, actionOutput, context);
         if (constrainedObject instanceof Element) {
             Element e = (Element) constrainedObject;
-            Debug.outln("constraints for " + e.getHumanName() + ", " + e.getID() + ": "
+            Debug.outln("constraints for " + e.getHumanName() + ", " + Converters.getElementToIdConverter().apply(e) + ": "
                     + MoreToString.Helper.toString(constraints));
         }
         else {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/generator/PresentationElementUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/generator/PresentationElementUtils.java
@@ -12,6 +12,7 @@ import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import com.nomagic.uml2.impl.ElementsFactory;
 import gov.nasa.jpl.mbee.mdk.api.docgen.presentation_elements.PresentationElementEnum;
 import gov.nasa.jpl.mbee.mdk.api.incubating.MDKConstants;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -115,7 +116,7 @@ public class PresentationElementUtils {
                         try {
                             JSONObject ob = (JSONObject) (new JSONParser()).parse(((LiteralString) is.getSpecification()).getValue());
                             //TODO sourceProperty json key migration? @donbot
-                            if (view.getID().equals(ob.get("sourceId")) && "documentation".equals(ob.get("sourceProperty"))) {
+                            if (Converters.getElementToIdConverter().apply(view).equals(ob.get("sourceId")) && "documentation".equals(ob.get("sourceProperty"))) {
                                 viewinstance = false; //a view doc instance
                                 res.setViewDocHack(is);
                             }
@@ -291,7 +292,7 @@ public class PresentationElementUtils {
         if (is == null) {
             is = ef.createInstanceSpecificationInstance();
             Application.getInstance().getProject().getCounter().setCanResetIDForObject(true);
-            is.setID(MDKConstants.HIDDEN_ID_PREFIX + is.getID() + ID_SUFFIX);
+            is.setID(MDKConstants.HIDDEN_ID_PREFIX + Converters.getElementToIdConverter().apply(is) + ID_SUFFIX);
             if (!pe.isViewDocHack()) {
                 Slot s = ef.createSlotInstance();
                 s.setOwner(is);
@@ -316,10 +317,10 @@ public class PresentationElementUtils {
         String name;
         if (pe.isViewDocHack()) {
             newspec = new JSONObject();
-            newspec.put("source", is.getID());
+            newspec.put("source", Converters.getElementToIdConverter().apply(is));
             newspec.put("type", "Paragraph");
             newspec.put("sourceProperty", "documentation");
-            String transclude = "<p>&nbsp;</p><p><mms-transclude-doc data-mms-eid=\"" + pe.getView().getID() + "\">[cf." + ((NamedElement) pe.getView()).getName() + ".doc]</mms-transclude-doc></p><p>&nbsp;</p>";
+            String transclude = "<p>&nbsp;</p><p><mms-transclude-doc data-mms-eid=\"" + Converters.getElementToIdConverter().apply(pe.getView()) + "\">[cf." + ((NamedElement) pe.getView()).getName() + ".doc]</mms-transclude-doc></p><p>&nbsp;</p>";
             ModelHelper.setComment(is, transclude);
             name = "View Documentation";
             classifier = tparaC;
@@ -396,7 +397,7 @@ public class PresentationElementUtils {
         }
         c = ef.createConstraintInstance();
         Application.getInstance().getProject().getCounter().setCanResetIDForObject(true);
-        c.setID(view.getID() + "_vc");
+        c.setID(Converters.getElementToIdConverter().apply(view) + "_vc");
         c.setOwner(view);
         c.getConstrainedElement().add(view);
         return c;
@@ -406,7 +407,7 @@ public class PresentationElementUtils {
         Constraint c = getOrCreateViewConstraint(view);
         Expression expression = c.getSpecification() instanceof Expression ? (Expression) c.getSpecification() : ef.createExpressionInstance();
         Application.getInstance().getProject().getCounter().setCanResetIDForObject(true);
-        expression.setID(view.getID() + "_vc_expression");
+        expression.setID(Converters.getElementToIdConverter().apply(view) + "_vc_expression");
         expression.setOwner(c);
         List<InstanceValue> instanceValues = new ArrayList<>(instanceSpecifications.size());
         Iterator<ValueSpecification> operandIterator = expression.getOperand().iterator();

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/generator/ViewPresentationGenerator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/generator/ViewPresentationGenerator.java
@@ -134,12 +134,13 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
 
         for (Element view : viewHierarchyVisitor.getView2ViewElements().keySet()) {
             if (processedElements.contains(view)) {
-                Application.getInstance().getGUILog().log("Detected duplicate view reference. Skipping generation for " + view.getID() + ".");
+                Application.getInstance().getGUILog().log("Detected duplicate view reference. Skipping generation for " + Converters.getElementToIdConverter().apply(view) + ".");
                 continue;
             }
-            ViewMapping viewMapping = viewMap.containsKey(view.getID()) ? viewMap.get(view.getID()) : new ViewMapping();
+            ViewMapping viewMapping = viewMap.containsKey(Converters.getElementToIdConverter().apply(view)) ?
+                    viewMap.get(Converters.getElementToIdConverter().apply(view)) : new ViewMapping();
             viewMapping.setElement(view);
-            viewMap.put(view.getID(), viewMapping);
+            viewMap.put(Converters.getElementToIdConverter().apply(view), viewMapping);
         }
 
         // Find and delete existing view constraints to prevent ID conflict when importing. Migration should handle this,
@@ -161,7 +162,7 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
             SessionManager.getInstance().createSession("Legacy View Constraint Purge");
             for (Constraint constraint : constraintsToBeDeleted) {
                 if (constraint.isEditable()) {
-                    Application.getInstance().getGUILog().log("Deleting legacy view constraint: " + constraint.getID());
+                    Application.getInstance().getGUILog().log("Deleting legacy view constraint: " + Converters.getElementToIdConverter().apply(constraint));
                     try {
                         ModelElementsManager.getInstance().removeElement(constraint);
                     } catch (ReadOnlyElementException e) {
@@ -244,10 +245,10 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                                     continue;
                                 }*/
                                     if (generatedFromViewProperty != null) {
-                                        slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + generatedFromViewProperty.getID());
+                                        slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + Converters.getElementToIdConverter().apply(generatedFromViewProperty));
                                     }
                                     if (generatedFromElementProperty != null) {
-                                        slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + generatedFromElementProperty.getID());
+                                        slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + Converters.getElementToIdConverter().apply(generatedFromElementProperty));
                                     }
                                     instanceIDs.add(instanceId);
                                     viewInstanceIDs.add(instanceId);
@@ -299,10 +300,10 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                                             continue;
                                         }*/
                                         if (generatedFromViewProperty != null) {
-                                            slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + generatedFromViewProperty.getID());
+                                            slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + Converters.getElementToIdConverter().apply(generatedFromViewProperty));
                                         }
                                         if (generatedFromElementProperty != null) {
-                                            slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + generatedFromElementProperty.getID());
+                                            slotIDs.add(instanceId + MDKConstants.SLOT_ID_SEPARATOR + Converters.getElementToIdConverter().apply(generatedFromElementProperty));
                                         }
                                         instanceIDs.add(instanceId);
                                     }
@@ -346,7 +347,8 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                                     EStructuralFeatureOverride.OWNER.getPredicate(),
                                     (objectNode, eStructuralFeature, project, strict, element) -> {
                                         if (element instanceof InstanceSpecification) {
-                                            element.setOwner(getIdToElementConverter().apply(project.getPrimaryProject().getProjectID(), project));
+                                            // TODO @donbot confirm that this doesn't set owner to null
+                                            element.setOwner(getIdToElementConverter().apply(Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()), project));
                                             return element;
                                         }
                                         return EStructuralFeatureOverride.OWNER.getFunction().apply(objectNode, eStructuralFeature, project, strict, element);
@@ -521,7 +523,7 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                 viewInProject.addViolation(violation);
                 skippedViews.add(view);
             }
-            if (!viewIDs.contains(view.getID())) {
+            if (!viewIDs.contains(Converters.getElementToIdConverter().apply(view))) {
                 ValidationRuleViolation violation = new ValidationRuleViolation(view, "View does not exist on MMS. Generation skipped.");
                 viewDoesNotExist.addViolation(violation);
                 skippedViews.add(view);
@@ -565,7 +567,7 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                     continue;
                 }
                 Object o;
-                ObjectNode serverViewJson = (o = viewMap.get(view.getID())) != null ? ((ViewMapping) o).getObjectNode() : null;
+                ObjectNode serverViewJson = (o = viewMap.get(Converters.getElementToIdConverter().apply(view))) != null ? ((ViewMapping) o).getObjectNode() : null;
                 if (!JsonEquivalencePredicate.getInstance().test(clientViewJson, serverViewJson)) {
                     if (MDUtils.isDeveloperMode()) {
                         Application.getInstance().getGUILog().log("View diff for " + Converters.getElementToIdConverter().apply(view) + ": " + JsonDiffFunction.getInstance().apply(clientViewJson, serverViewJson).toString());
@@ -600,7 +602,8 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                 if (clientInstanceSpecificationJson == null) {
                     continue;
                 }
-                ObjectNode serverInstanceSpecificationJson = instanceSpecificationMap.containsKey(instance.getID()) ? instanceSpecificationMap.get(instance.getID()).getFirst() : null;
+                ObjectNode serverInstanceSpecificationJson = instanceSpecificationMap.containsKey(Converters.getElementToIdConverter().apply(instance)) ?
+                        instanceSpecificationMap.get(Converters.getElementToIdConverter().apply(instance)).getFirst() : null;
                 if (!JsonEquivalencePredicate.getInstance().test(clientInstanceSpecificationJson, serverInstanceSpecificationJson)) {
                     if (MDUtils.isDeveloperMode()) {
                         Application.getInstance().getGUILog().log("View Instance diff for " + Converters.getElementToIdConverter().apply(instance) + ": " + JsonDiffFunction.getInstance().apply(clientInstanceSpecificationJson, serverInstanceSpecificationJson).toString());
@@ -612,7 +615,8 @@ public class ViewPresentationGenerator implements RunnableWithProgress {
                     if (clientSlotJson == null) {
                         continue;
                     }
-                    JsonNode serverSlotJson = slotMap.containsKey(slot.getID()) ? slotMap.get(slot.getID()).getFirst() : null;
+                    JsonNode serverSlotJson = slotMap.containsKey(Converters.getElementToIdConverter().apply(slot)) ?
+                            slotMap.get(Converters.getElementToIdConverter().apply(slot)).getFirst() : null;
                     if (!JsonEquivalencePredicate.getInstance().test(clientSlotJson, serverSlotJson)) {
                         elementsArrayNode.add(clientSlotJson);
                         if (MDUtils.isDeveloperMode()) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/lib/EmfUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/lib/EmfUtils.java
@@ -34,6 +34,7 @@ package gov.nasa.jpl.mbee.mdk.lib;
 import com.nomagic.uml2.ext.jmi.helpers.StereotypesHelper;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import junit.framework.Assert;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.ENamedElement;
@@ -106,7 +107,7 @@ public final class EmfUtils {
                 repText = ":" + repText;
             }
             result = name + // e.getHumanType() + ":" +
-                    (Debug.isOn() ? e.getID() : "") + repText;
+                    (Debug.isOn() ? Converters.getElementToIdConverter().apply(e) : "") + repText;
             result = result.replaceFirst("::", ":");
             result = result.trim().replaceAll("^:", "");
             result = result.trim().replaceAll(":$", "");

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/lib/MDUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/lib/MDUtils.java
@@ -245,8 +245,8 @@ public class MDUtils {
         if (!project.isRemote()) {
             return "master";
         }
-        return EsiUtils.getCurrentBranch(project.getPrimaryProject()).getName();
 //        return getRemoteBranchPath(ProjectDescriptorsFactory.createAnyRemoteProjectDescriptor(project).getURI());
+        return EsiUtils.getCurrentBranch(project.getPrimaryProject()).getName();
     }
 
     public static String getRemoteBranchPath(URI uri) {
@@ -254,13 +254,12 @@ public class MDUtils {
         return ProjectDescriptorsFactory.getProjectBranchPath(uri);
     }
 
-    public static int getRemoteVersion(Project project) {
+    public static long getRemoteVersion(Project project) {
         if (!project.isRemote()) {
             return -1;
         }
 //        return getRemoteVersion(ProjectDescriptorsFactory.createAnyRemoteProjectDescriptor(project).getURI());
-        // TODO @donbot this returns a long, not an int. decide if we should migrate
-        return Integer.valueOf(ProjectUtilities.getVersion(project.getPrimaryProject()).getName());
+        return Long.valueOf(ProjectUtilities.getVersion(project.getPrimaryProject()).getName());
     }
 
 
@@ -268,7 +267,7 @@ public class MDUtils {
         return ProjectDescriptorsFactory.getRemoteVersion(uri);
     }
 
-    public static int getLatestEsiVersion(Project project) {
+    public static long getLatestEsiVersion(Project project) {
         if (!project.isRemote()) {
             return -1;
         }
@@ -277,8 +276,9 @@ public class MDUtils {
 
 
     // TODO Switch to convenience method in 18.5 @donbot
-    public static int getLatestEsiVersion(ProjectDescriptor projectDescriptor) {
-        final int[] version = new int[]{-1};
+    // note that this only converts version to int, despite being compared with a long from the getRemoteVersion methods
+    public static long getLatestEsiVersion(ProjectDescriptor projectDescriptor) {
+        final long[] version = new long[]{-1};
         EsiUtils.getVersions(projectDescriptor).stream().max(ProjectUtilities::compareVersions).ifPresent(iVersionDescriptor -> version[0] = ProjectUtilities.versionToInt(iVersionDescriptor.getName()));
         return version[0];
     }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/lib/MDUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/lib/MDUtils.java
@@ -258,8 +258,11 @@ public class MDUtils {
         if (!project.isRemote()) {
             return -1;
         }
-        return getRemoteVersion(ProjectDescriptorsFactory.createAnyRemoteProjectDescriptor(project).getURI());
+//        return getRemoteVersion(ProjectDescriptorsFactory.createAnyRemoteProjectDescriptor(project).getURI());
+        // TODO @donbot this returns a long, not an int. decide if we should migrate
+        return Integer.valueOf(ProjectUtilities.getVersion(project.getPrimaryProject()).getName());
     }
+
 
     public static int getRemoteVersion(URI uri) {
         return ProjectDescriptorsFactory.getRemoteVersion(uri);
@@ -279,13 +282,5 @@ public class MDUtils {
         EsiUtils.getVersions(projectDescriptor).stream().max(ProjectUtilities::compareVersions).ifPresent(iVersionDescriptor -> version[0] = ProjectUtilities.versionToInt(iVersionDescriptor.getName()));
         return version[0];
     }
-
-    public static String getProjectID(Project project) {
-        if (project.isRemote()) {
-            return ProjectUtilities.getResourceID(project.getPrimaryProject().getLocationURI());
-        }
-        return project.getID();
-    }
-
 
 }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/lib/Utils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/lib/Utils.java
@@ -67,6 +67,7 @@ import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import com.nomagic.uml2.impl.ElementsFactory;
 import gov.nasa.jpl.mbee.mdk.DocGenUtils;
 import gov.nasa.jpl.mbee.mdk.api.ElementFinder;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.docgen.docbook.*;
 import gov.nasa.jpl.mbee.mdk.docgen.table.EditableTable;
 import gov.nasa.jpl.mbee.mdk.docgen.table.EditableTableModel;
@@ -2129,7 +2130,7 @@ public class Utils {
         if (view != null) {
             Collection<Constraint> constraints = view.get_constraintOfConstrainedElement();
             for (Constraint constraint : constraints) {
-                if (constraint != null && constraint.getID().endsWith(("_vc"))) {
+                if (constraint != null && Converters.getElementToIdConverter().apply(constraint).endsWith(("_vc"))) {
                     return constraint;
                 }
             }
@@ -3640,6 +3641,8 @@ public class Utils {
         else {
             s = type;
         }
+
+        // TODO @donbot BaseElement doesn't have getLocalID(), confirm that this doesn't need to be migrated to getElementToIDConverter
         if (includeId && o instanceof BaseElement) {
             if (!Utils2.isNullOrEmpty(s)) {
                 s = s + ":" + ((BaseElement) o).getID();

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/lib/Utils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/lib/Utils.java
@@ -67,6 +67,7 @@ import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import com.nomagic.uml2.impl.ElementsFactory;
 import gov.nasa.jpl.mbee.mdk.DocGenUtils;
 import gov.nasa.jpl.mbee.mdk.api.ElementFinder;
+import gov.nasa.jpl.mbee.mdk.api.incubating.MDKConstants;
 import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.docgen.docbook.*;
 import gov.nasa.jpl.mbee.mdk.docgen.table.EditableTable;
@@ -2130,7 +2131,7 @@ public class Utils {
         if (view != null) {
             Collection<Constraint> constraints = view.get_constraintOfConstrainedElement();
             for (Constraint constraint : constraints) {
-                if (constraint != null && Converters.getElementToIdConverter().apply(constraint).endsWith(("_vc"))) {
+                if (constraint != null && Converters.getElementToIdConverter().apply(constraint).endsWith((MDKConstants.VIEW_CONSTRAINT_SYSML_ID_SUFFIX))) {
                     return constraint;
                 }
             }
@@ -2138,6 +2139,23 @@ public class Utils {
         }
         return null;
     }
+
+    public static Constraint getWarningConstraint() {
+        return (Constraint) Application.getInstance().getProject().getElementByID("_17_0_2_2_f4a035d_1360957024690_702520_27755");
+    }
+
+    public static Constraint getErrorConstraint() {
+        return (Constraint) Application.getInstance().getProject().getElementByID("_17_0_2_407019f_1354058024392_224770_12910");
+    }
+
+    public static Constraint getFatalConstraint() {
+        return (Constraint) Application.getInstance().getProject().getElementByID("_17_0_2_2_f4a035d_1360957445325_901851_27756");
+    }
+
+    public static Constraint getInfoConstraint() {
+        return (Constraint) Application.getInstance().getProject().getElementByID("_17_0_2_2_f4a035d_1360957474351_901777_27765");
+    }
+
     /********************************************* User interaction ****************************************************/
 
     /**
@@ -2383,8 +2401,7 @@ public class Utils {
                                                               Constraint cons) {
         List<RuleViolationResult> results = new ArrayList<RuleViolationResult>();
         // Project project = getProject();
-        // Constraint cons =
-        // (Constraint)project.getElementByID("_17_0_2_2_f4a035d_1360957024690_702520_27755");
+        // Constraint cons = Utils.getWarningConstraint();
 
         EnumerationLiteral severity;
         /*
@@ -2396,19 +2413,19 @@ public class Utils {
         switch (vr.getSeverity()) {
             case WARNING:
                 severity = Annotation.getSeverityLevel(project, Annotation.WARNING);
-                cons = (Constraint) project.getElementByID("_17_0_2_2_f4a035d_1360957024690_702520_27755");
+                cons = Utils.getWarningConstraint();
                 break;
             case ERROR:
                 severity = Annotation.getSeverityLevel(project, Annotation.ERROR);
-                cons = (Constraint) project.getElementByID("_17_0_2_407019f_1354058024392_224770_12910");
+                cons = Utils.getErrorConstraint();
                 break;
             case FATAL:
                 severity = Annotation.getSeverityLevel(project, Annotation.FATAL);
-                cons = (Constraint) project.getElementByID("_17_0_2_2_f4a035d_1360957445325_901851_27756");
+                cons = Utils.getFatalConstraint();
                 break;
             case INFO:
                 severity = Annotation.getSeverityLevel(project, Annotation.INFO);
-                cons = (Constraint) project.getElementByID("_17_0_2_2_f4a035d_1360957474351_901777_27765");
+                cons = Utils.getInfoConstraint();
                 break;
             default:
                 severity = Annotation.getSeverityLevel(project, Annotation.WARNING);
@@ -2445,7 +2462,7 @@ public class Utils {
     public static List<RuleViolationResult> getRuleViolations(Collection<ValidationSuite> vss) {
         List<RuleViolationResult> results = new ArrayList<RuleViolationResult>();
         Project project = getProject();
-        Constraint cons = (Constraint) project.getElementByID("_17_0_2_2_f4a035d_1360957024690_702520_27755");
+        Constraint cons = Utils.getWarningConstraint();
         for (ValidationSuite vs : vss) {
             for (ValidationRule vr : vs.getValidationRules()) {
                 results.addAll(getRuleViolations(vr, project, cons));
@@ -2474,7 +2491,7 @@ public class Utils {
         // Collection<RuleViolationResult> results = new
         // ArrayList<RuleViolationResult>();
         Package dummyvs = (Package) project.getElementByID("_17_0_2_407019f_1354124289134_280378_12909");
-        //Constraint cons = (Constraint)project.getElementByID("_17_0_2_2_f4a035d_1360957024690_702520_27755");
+        //Constraint cons = Utils.getWarningConstraint();
         if (dummyvs == null) {
             //Utils.showPopupMessage("You don't have SysML Extensions mounted! You need it in order for the validations to show.");
             Application.getInstance().getGUILog().log("You don't have SysML Extensions mounted! You need it in order for the validations to show.");
@@ -3736,7 +3753,7 @@ public class Utils {
         }
         String user = EsiUtils.getLoggedUserName();
         try {
-            int lastVersion = MDUtils.getLatestEsiVersion(project);
+            long lastVersion = MDUtils.getLatestEsiVersion(project);
             if (user == null || lastVersion < 0) {
                 Utils.guilog("[ERROR] You must be logged into Teamwork Cloud first.");
                 return false;

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/model/HierarchyMigrationVisitor.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/model/HierarchyMigrationVisitor.java
@@ -8,6 +8,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.*;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
 import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import com.nomagic.uml2.impl.ElementsFactory;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 
 import java.util.List;
@@ -87,8 +88,8 @@ public class HierarchyMigrationVisitor extends AbstractModelVisitor {
     private void setId(Element old, Element neww) {
         if (old.isEditable()) {
             if (!(old instanceof Diagram)) {
-                String oldId = old.getID();
-                String newId = neww.getID();
+                String oldId = Converters.getElementToIdConverter().apply(old);
+                String newId = Converters.getElementToIdConverter().apply(neww);
                 neww.setID(oldId);
                 old.setID(newId);
             }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/model/Image.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/model/Image.java
@@ -31,6 +31,7 @@ package gov.nasa.jpl.mbee.mdk.model;
 import com.nomagic.uml2.ext.jmi.helpers.ModelHelper;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Diagram;
 import gov.nasa.jpl.mbee.mdk.DocGen3Profile;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.GeneratorUtils;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 import gov.nasa.jpl.mbee.mdk.docgen.docbook.DBImage;
@@ -103,7 +104,7 @@ public class Image extends Query {
                     if (getCaptions() != null && getCaptions().size() > i && getShowCaptions()) {
                         im.setCaption(getCaptions().get(i));
                     }
-                    im.setId(diagram.getID());
+                    im.setId(Converters.getElementToIdConverter().apply(diagram));
                     res.add(im);
 
                     String doc = ModelHelper.getComment(diagram);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/model/LibraryMapping.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/model/LibraryMapping.java
@@ -41,6 +41,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.*;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 import com.nomagic.uml2.impl.ElementsFactory;
 import gov.nasa.jpl.mbee.mdk.DocGenUtils;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 import gov.nasa.jpl.mbee.mdk.lib.Utils2;
 import gov.nasa.jpl.mbee.mdk.model.ui.LibraryChooserUI;
@@ -344,7 +345,7 @@ public class LibraryMapping extends Query {
     }
 
     private Node<String, LibraryComponent> fillComponent(NamedElement cur) {
-        Node<String, LibraryComponent> node = new Node<String, LibraryComponent>(cur.getID(),
+        Node<String, LibraryComponent> node = new Node<>(Converters.getElementToIdConverter().apply(cur),
                 new LibraryComponent(cur.getName(), cur));
         if (cur instanceof Package) {
             for (Element e : cur.getOwnedElement()) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/model/MissionMapping.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/model/MissionMapping.java
@@ -40,6 +40,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 import com.nomagic.uml2.impl.ElementsFactory;
 import gov.nasa.jpl.mbee.mdk.DocGenUtils;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.lib.Utils;
 import gov.nasa.jpl.mbee.mdk.lib.Utils2;
 import gov.nasa.jpl.mbee.mdk.model.ui.CharacterizationChooserUI;
@@ -529,7 +530,7 @@ public class MissionMapping extends Query {
     }
 
     private Node<String, MissionComponent> fillMission(NamedElement cur) {
-        Node<String, MissionComponent> node = new Node<String, MissionComponent>(cur.getID(),
+        Node<String, MissionComponent> node = new Node<>(Converters.getElementToIdConverter().apply(cur),
                 new MissionComponent(cur.getName(), cur));
         if (cur instanceof Package) {
             if (IMCEPresent) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/model/TimeQueryUtil.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/model/TimeQueryUtil.java
@@ -7,6 +7,7 @@ import com.nomagic.magicdraw.core.Application;
 import com.nomagic.magicdraw.core.GUILog;
 import com.nomagic.magicdraw.core.Project;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.MMSUtils;
 import gov.nasa.jpl.mbee.mdk.ems.ServerException;
 import gov.nasa.jpl.mbee.mdk.json.JacksonUtils;
@@ -48,9 +49,9 @@ public class TimeQueryUtil {
         Utils.guilog("[INFO] Getting elements from server...");
 
         for (Element elem : elementsToQuery) {
-            String id = elem.getID();
+            String id = Converters.getElementToIdConverter().apply(elem);
             if (elem == project) {
-                id = Application.getInstance().getProject().getPrimaryProject().getProjectID();
+                id = Converters.getIProjectToIdConverter().apply(project.getPrimaryProject());
             }
             id = id.replace(".", "%2E");
             requestUri.setPath(basePath + "/" + id);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/ocl/OclEvaluator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/ocl/OclEvaluator.java
@@ -38,6 +38,7 @@ import com.nomagic.uml2.ext.magicdraw.mdprofiles.Stereotype;
 import gov.nasa.jpl.mbee.mdk.DocGen3Profile;
 import gov.nasa.jpl.mbee.mdk.DocGenUtils;
 import gov.nasa.jpl.mbee.mdk.api.ElementFinder;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.generator.DocumentGenerator;
 import gov.nasa.jpl.mbee.mdk.generator.DocumentValidator;
 import gov.nasa.jpl.mbee.mdk.generator.ViewParser;
@@ -568,7 +569,8 @@ public class OclEvaluator {
                 String nameOrId = (String) args[0];
 
                 // try id
-                BaseElement e = Application.getInstance().getProject().getElementByID(nameOrId);
+                BaseElement e = Converters.getIdToElementConverter()
+                        .apply(nameOrId, Application.getInstance().getProject());
                 if (e != null) {
                     return e;
                 }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/viewedit/DBAlfrescoVisitor.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/viewedit/DBAlfrescoVisitor.java
@@ -144,7 +144,7 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
         // export image - also keep track of exported images
         DiagramPresentationElement diagram = Application.getInstance().getProject()
                 .getDiagram(image.getImage());
-        String svgFilename = image.getImage().getID();
+        String svgFilename = Converters.getElementToIdConverter().apply(image.getImage());
 
         // create image file
         String userhome = System.getProperty("user.home");
@@ -184,7 +184,7 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
 
         // Lets rename the file to have the hash code
         // make sure this matches what's in the View Editor ImageResource.java
-        String svgCrcFilename = image.getImage().getID() + "_latest" + FILE_EXTENSION;
+        String svgCrcFilename = Converters.getElementToIdConverter().apply(image.getImage()) + "_latest" + FILE_EXTENSION;
         //gl.log("Exporting diagram to: " + svgDiagramFile.getAbsolutePath());
 
         // keep record of all images found
@@ -196,7 +196,7 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
         //MDEV #674 -- Update the type and id: was hard coded.
         //
         entry.put("type", "Image");
-        entry.put(MDKConstants.SYSML_ID_KEY, image.getImage().getID());
+        entry.put(MDKConstants.SYSML_ID_KEY, Converters.getElementToIdConverter().apply(image.getImage()));
         entry.put("title", image.getTitle());
         curContains.peek().add(entry);
 
@@ -332,7 +332,7 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
             }
             //sibviews.pop();
             if (section.isNoSection()) {
-                noSections.add(eview.getID());
+                noSections.add(Converters.getElementToIdConverter().apply(eview));
             }
             endView(eview);
         }
@@ -369,8 +369,8 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
         entry.put("tstype" , tomSawyerDiagram.getShortType().toString());
         // here enter a list of all the elements we need.
         JSONArray elements = new JSONArray();
-        for(Element elem : tomSawyerDiagram.getElements()){
-        elements.add(elem.getID());
+        for(Element elem : tomSawyerDiagram.getElements()) {
+            elements.add(Converters.getElementToIdConverter().apply(elem));
         }
 
         entry.put("elements", elements);
@@ -429,7 +429,7 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
         else {
             view.put("type", "View");
         }
-        String id = e.getID();
+        String id = Converters.getElementToIdConverter().apply(e);
         view.put(MDKConstants.SYSML_ID_KEY, id);
         views.put(id, view);
         Set<String> viewE = new HashSet<String>();
@@ -442,7 +442,7 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
         /*for (Element exposed: Utils.collectDirectedRelatedElementsByRelationshipStereotypeString(e,
                 DocGen3Profile.queriesStereotype, 1, false, 1))
             addToElements(exposed);*/
-        sibviews.peek().add(e.getID());
+        sibviews.peek().add(Converters.getElementToIdConverter().apply(e));
         sibviewsElements.peek().add(e);
         JSONArray childViews = new JSONArray();
         sibviews.push(childViews);
@@ -472,14 +472,14 @@ public class DBAlfrescoVisitor extends DBAbstractVisitor {
         //MDEV #673: update code to use the
         //specialization element.
         //
-        JSONObject view = (JSONObject) views.get(e.getID());
+        JSONObject view = (JSONObject) views.get(Converters.getElementToIdConverter().apply(e));
 
         view.put("displayedElements", viewEs);
         view.put("allowedElements", viewEs);
         if (recurse && !doc) {
             view.put("childrenViews", sibviews.peek());
         }
-        view2view.put(e.getID(), sibviews.pop());
+        view2view.put(Converters.getElementToIdConverter().apply(e), sibviews.pop());
         view2viewElements.put(e, sibviewsElements.pop());
         this.curContains.pop();
 

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/viewedit/ViewHierarchyVisitor.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/viewedit/ViewHierarchyVisitor.java
@@ -29,6 +29,7 @@
 package gov.nasa.jpl.mbee.mdk.viewedit;
 
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.model.AbstractModelVisitor;
 import gov.nasa.jpl.mbee.mdk.model.Document;
 import gov.nasa.jpl.mbee.mdk.model.Section;
@@ -63,7 +64,7 @@ public class ViewHierarchyVisitor extends AbstractModelVisitor {
         }
         visitChildren(doc);
         if (doc.getDgElement() != null) {
-            result.put(doc.getDgElement().getID(), curChildren.pop());
+            result.put(Converters.getElementToIdConverter().apply(doc.getDgElement()), curChildren.pop());
             resultElements.put(doc.getDgElement(), curChildrenElements.pop());
         }
     }
@@ -73,18 +74,18 @@ public class ViewHierarchyVisitor extends AbstractModelVisitor {
     public void visit(Section sec) {
         if (sec.isView()) {
             if (sec.isNoSection()) {
-                nosections.add(sec.getDgElement().getID());
+                nosections.add(Converters.getElementToIdConverter().apply(sec.getDgElement()));
             }
             if (!curChildren.isEmpty()) {
-                curChildren.peek().add(sec.getDgElement().getID());
+                curChildren.peek().add(Converters.getElementToIdConverter().apply(sec.getDgElement()));
                 curChildrenElements.peek().add(sec.getDgElement());
             }
             curChildren.push(new JSONArray());
-            curChildrenElements.push(new ArrayList<Element>());
+            curChildrenElements.push(new ArrayList<>());
         }
         visitChildren(sec);
         if (sec.isView()) {
-            result.put(sec.getDgElement().getID(), curChildren.pop());
+            result.put(Converters.getElementToIdConverter().apply(sec.getDgElement()), curChildren.pop());
             resultElements.put(sec.getDgElement(), curChildrenElements.pop());
         }
     }

--- a/src/main/java/gov/nasa/jpl/mbee/pma/analyses/AutomatedViewGeneration.java
+++ b/src/main/java/gov/nasa/jpl/mbee/pma/analyses/AutomatedViewGeneration.java
@@ -12,6 +12,7 @@ import com.nomagic.teamwork.common.users.SessionInfo;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
 import gov.nasa.jpl.mbee.mdk.api.MDKHelper;
 import gov.nasa.jpl.mbee.mdk.api.MagicDrawHelper;
+import gov.nasa.jpl.mbee.mdk.api.incubating.convert.Converters;
 import gov.nasa.jpl.mbee.mdk.ems.ServerException;
 import gov.nasa.jpl.mbee.mdk.options.MDKOptionsGroup;
 
@@ -366,7 +367,8 @@ public class AutomatedViewGeneration extends CommandLine {
         logMessage(msg);
         boolean failedDocs = false;
         for (String elementID : viewList) {
-            NamedElement document = (NamedElement) Application.getInstance().getProject().getElementByID(elementID);
+            NamedElement document = (NamedElement) Converters.getIdToElementConverter()
+                    .apply(elementID, Application.getInstance().getProject());
             if (document == null) {
                 msg = "[FAILURE] Unable to find element \"" + elementID + "\"";
                 logMessage(msg);


### PR DESCRIPTION
Refactored uses of element.getID() and iProject.getProjectID() and project.getID to use Converters.getObjectToIdConverter to support separating local ids and TWC uuids.