### PR TITLE
MAGICDRAW-765

### DIFF
--- a/src/main/java/gov/nasa/jpl/mbee/mdk/systems_reasoner/actions/SetOrCreateRedefinableElementAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/systems_reasoner/actions/SetOrCreateRedefinableElementAction.java
@@ -66,13 +66,42 @@ public class SetOrCreateRedefinableElementAction extends GenericRuleViolationAct
 
         if (elementToBeRedefined instanceof Property) {
             if (((Property) elementToBeRedefined).getAssociation() != null) {
-                createInheritingAssociation((Property) elementToBeRedefined, subClassifier, (Property) redefinedElement);
+                if(!existingAssociationInheritsFromGeneralAssociation(redefinedElement, (Property) elementToBeRedefined)) {
+                    createInheritingAssociation((Property) elementToBeRedefined, subClassifier, (Property) redefinedElement);
+                }
             }
         }
         if (isRecursive && redefinedElement instanceof Property && ((TypedElement) redefinedElement).getType() != null) {
             CreateSpecializedTypeAction.createSpecializedType((Property) redefinedElement, subClassifier, traveled, visited, isIndividual, isRecursive);
         }
         return redefinedElement;
+    }
+
+    private static boolean existingAssociationInheritsFromGeneralAssociation(RedefinableElement redefinedElement, Property elementToBeRedefined) {
+        if(redefinedElement instanceof Property) {
+            Association association = ((Property) redefinedElement).getAssociation();
+            Association general = elementToBeRedefined.getAssociation();
+            if(association != null) {
+                return eventuallyInherits(association, general);
+            }else{
+                return false;
+            }
+
+        }
+        return false;
+    }
+
+    private static boolean eventuallyInherits(Classifier association, Classifier general) {
+        if(association.getGeneral().contains(general)){
+            return true;
+        }else{
+            for (Classifier specific : association.getGeneral()) {
+                if(eventuallyInherits(specific, general)){
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     private static RedefinableElement findExistingRedefiningElement(Classifier subClassifier, RedefinableElement elementToBeRedefined) {


### PR DESCRIPTION
Avoid creating secondary Associations for inherited properties that are redefining another property with an Association.
Before: Two associations were created, one was corrupted.
After: Only one association is created (specializing the more specific one).