### PR TITLE
Modified to fix MAGICDRAW-966

### DIFF
--- a/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/docbook/DBTable.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/docgen/docbook/DBTable.java
@@ -138,10 +138,10 @@ public class DBTable extends DocumentElement {
         //this whole thing looks complicated because of transposing colspans and rowspans
         //the new table wouldn't have a header since the new header would be part of the body
         removeAllNulls(); //every cell should be a document element, this is to remove any inconsistent user set nulls
-        addNulls(); //go through the current table and add in nulls according to colspans and rowspans 
+        addNulls(); //go through the current table and add in nulls according to colspans and rowspans
         //so the table is truly m x n, every cell should be either null or a document element
 
-        //do the transpose, if i is index of the col and j is index of the row in the old table, 
+        //do the transpose, if i is index of the col and j is index of the row in the old table,
         //the new table's rows would be i and cols would be j
         List<List<DocumentElement>> newbody = new ArrayList<List<DocumentElement>>();
         if (headers != null && headers.size() > 0) {
@@ -211,8 +211,15 @@ public class DBTable extends DocumentElement {
                 }
             }
         }
-        this.body = newbody;
         this.headers = null;
+        List<DocumentElement> newColumnHeader = newbody.get(newbody.size()-1);
+        if (isRowHeader(newColumnHeader)) //if true assume to be having row and column headers.
+        {
+            this.headers = new ArrayList<List<DocumentElement>>();
+            this.headers.add(newColumnHeader);
+            newbody.remove(newbody.size() -1);
+        }
+        this.body = newbody;
         this.cols = !newbody.isEmpty() ? newbody.get(0).size() : 0;
         List<DBColSpec> newcolspecs = new ArrayList<DBColSpec>();
         for (int i = 1; i <= cols; i++) {
@@ -220,6 +227,23 @@ public class DBTable extends DocumentElement {
         }
         this.colspecs = newcolspecs;
 
+    }
+    /*
+          return true if the transposed cell(0,0) has empty text string
+       */
+    private boolean isRowHeader(List<DocumentElement> newLastRow)
+    {
+        DocumentElement newLastRowFirstColumn = newLastRow.get(0);
+        if (newLastRowFirstColumn instanceof DBTableEntry)
+        {
+            DBTableEntry dt_newLastRowFirstColumn = ((DBTableEntry) newLastRowFirstColumn);
+            if(dt_newLastRowFirstColumn.getMorerows() == 0 && dt_newLastRowFirstColumn.getNamest() == null && dt_newLastRowFirstColumn.getNameend() == null){
+                if (dt_newLastRowFirstColumn.getChildren().get(0) instanceof DBText)
+                    if (((DBText)dt_newLastRowFirstColumn.getChildren().get(0)).getText().toString().length() == 0)
+                        return true;
+            }
+        }
+        return false;
     }
 
     private void removeAllNulls() {


### PR DESCRIPTION
Modify for feature/MAGICDRAW-966. When a table of cell(0,0) is DBTableEntry and its child is empty string DBText and transposed, the first column values are assumed to be row headers. Thus, the original first column values become the DBTable.headers.