### PR TITLE
MAGICDRAW-1056 Fix skipped MMS branch validation

### DIFF
--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/delta/DeltaSyncRunner.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/delta/DeltaSyncRunner.java
@@ -112,7 +112,7 @@ public class DeltaSyncRunner implements RunnableWithProgress {
                 Application.getInstance().getGUILog().log("[WARNING] MMS history is unavailable. Skipping sync. All changes will be re-attempted in the next sync.");
                 return;
             }
-        } catch (URISyntaxException | IOException | ServerException e) {
+        } catch (URISyntaxException | IOException | IllegalStateException | ServerException e) {
             Application.getInstance().getGUILog().log("[ERROR] An error occurred while updating MMS history. Credentials will be cleared. Skipping sync. All changes will be persisted in the model and re-attempted in the next sync. Reason: " + e.getMessage());
             e.printStackTrace();
             return;

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/BranchValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/BranchValidator.java
@@ -68,10 +68,7 @@ public class BranchValidator {
             return;
         }
 
-        String currentBranch = EsiUtils.getCurrentBranch(primaryProject).getName();
-        if (currentBranch.equals("trunk")) {
-            currentBranch = "master";
-        }
+        String currentBranch = EsiUtils.getCurrentBranch(primaryProject).getID().toString();
         Map<String, Pair<EsiUtils.EsiBranchInfo, ObjectNode>> clientBranches = new HashMap<>();
         Map<String, ObjectNode> serverBranches = new HashMap<>();
 
@@ -104,7 +101,7 @@ public class BranchValidator {
             branchJson.remove(MDKConstants.PARENT_REF_ID_KEY);
             JsonNode value;
             String entryKey;
-            if ((value = branchJson.get(MDKConstants.NAME_KEY)) != null && value.isTextual()) {
+            if ((value = branchJson.get(MDKConstants.ID_KEY)) != null && value.isTextual()) {
                 entryKey = value.asText();
                 if (allBranches || entryKey.equals(currentBranch)) {
                     clientBranches.put(entryKey, new Pair<>(branch, branchJson));
@@ -136,7 +133,7 @@ public class BranchValidator {
                         ObjectNode refObjectNode = (ObjectNode) refJson;
                         refObjectNode.remove(MDKConstants.PARENT_REF_ID_KEY);
                         String entryKey;
-                        if ((value = refObjectNode.get(MDKConstants.NAME_KEY)) != null && value.isTextual()) {
+                        if ((value = refObjectNode.get(MDKConstants.ID_KEY)) != null && value.isTextual()) {
                             entryKey = value.asText();
                             if (allBranches || entryKey.equals(currentBranch)) {
                                 serverBranches.put(entryKey, refObjectNode);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/BranchValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/BranchValidator.java
@@ -104,7 +104,7 @@ public class BranchValidator {
             branchJson.remove(MDKConstants.PARENT_REF_ID_KEY);
             JsonNode value;
             String entryKey;
-            if ((value = branchJson.get(MDKConstants.ID_KEY)) != null && value.isTextual()) {
+            if ((value = branchJson.get(MDKConstants.NAME_KEY)) != null && value.isTextual()) {
                 entryKey = value.asText();
                 if (allBranches || entryKey.equals(currentBranch)) {
                     clientBranches.put(entryKey, new Pair<>(branch, branchJson));
@@ -136,7 +136,7 @@ public class BranchValidator {
                         ObjectNode refObjectNode = (ObjectNode) refJson;
                         refObjectNode.remove(MDKConstants.PARENT_REF_ID_KEY);
                         String entryKey;
-                        if ((value = refObjectNode.get(MDKConstants.ID_KEY)) != null && value.isTextual()) {
+                        if ((value = refObjectNode.get(MDKConstants.NAME_KEY)) != null && value.isTextual()) {
                             entryKey = value.asText();
                             if (allBranches || entryKey.equals(currentBranch)) {
                                 serverBranches.put(entryKey, refObjectNode);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/BranchValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/BranchValidator.java
@@ -20,6 +20,7 @@ import gov.nasa.jpl.mbee.mdk.json.JacksonUtils;
 import gov.nasa.jpl.mbee.mdk.mms.MMSUtils;
 import gov.nasa.jpl.mbee.mdk.mms.actions.CommitBranchAction;
 import gov.nasa.jpl.mbee.mdk.mms.json.JsonPatchFunction;
+import gov.nasa.jpl.mbee.mdk.util.MDUtils;
 import gov.nasa.jpl.mbee.mdk.util.Pair;
 import gov.nasa.jpl.mbee.mdk.util.Utils;
 import gov.nasa.jpl.mbee.mdk.validation.ValidationRule;
@@ -68,7 +69,7 @@ public class BranchValidator {
             return;
         }
 
-        String currentBranch = EsiUtils.getCurrentBranch(primaryProject).getID().toString();
+        String currentBranch = MDUtils.getBranchId(project);
         Map<String, Pair<EsiUtils.EsiBranchInfo, ObjectNode>> clientBranches = new HashMap<>();
         Map<String, ObjectNode> serverBranches = new HashMap<>();
 


### PR DESCRIPTION
The validator was comparing the branch name field with the id field in the returned JSON, so it never matched.