### PR TITLE
Remove JCenter repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,10 @@ String[] classpathLibraries = ['lib/patch.jar','lib/brand.jar','lib/brand_api.ja
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
     dependencies {
         classpath group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.9.0'
@@ -38,7 +41,10 @@ apply plugin: 'rebel'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // mavenCentral()
+    mavenCentral()
+    maven {
+        url 'https://repo.gradle.org/gradle/libs-releases-local/'
+    }
     if (buildAccess == 'internal') {
         maven {
             url 'https://cae-artifactory.jpl.nasa.gov/artifactory/maven-libs-snapshot-virtual'
@@ -64,7 +70,6 @@ repositories {
             }
         }
     }
-    jcenter()
 }
 
 configurations {


### PR DESCRIPTION
This replaces JCenter (which is being sunsetted) with Maven Central and the Gradle Plugins and Releases repositories.

The NoMagic and internal repositories are now placed last to avoid hitting NoMagic's server for every dependency and to work around a Gradle bug causing a failure when pulling from the internal repository.