### PR TITLE
Remove overwrite parameter added for NOMAGIC-1205

### DIFF
--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/actions/CommitClientElementAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/actions/CommitClientElementAction.java
@@ -121,8 +121,6 @@ public class CommitClientElementAction extends RuleViolationAction implements An
             try {
                 File file = MMSUtils.createEntityFile(CommitClientElementAction.class, ContentType.APPLICATION_JSON, elementsToUpdate, MMSUtils.JsonBlobType.ELEMENT_JSON);
                 URIBuilder requestUri = MMSUtils.getServiceProjectsRefsElementsUri(project);
-                // Prevent potential "Not Equivalent" errors due to default merging of element data.
-                requestUri.addParameter("overwrite", "true");
                 HttpRequestBase request = MMSUtils.buildRequest(MMSUtils.HttpRequestType.POST, requestUri, file, ContentType.APPLICATION_JSON);
                 TaskRunner.runWithProgressStatus(progressStatus -> {
                     try {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/delta/DeltaSyncRunner.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/delta/DeltaSyncRunner.java
@@ -319,8 +319,6 @@ public class DeltaSyncRunner implements RunnableWithProgress {
             }
             if (!postElements.isEmpty()) {
                 URIBuilder requestUri = MMSUtils.getServiceProjectsRefsElementsUri(project);
-                // Prevent potential "Not Equivalent" errors due to default merging of element data.
-                requestUri.addParameter("overwrite", "true");
                 try {
                     File file = MMSUtils.createEntityFile(this.getClass(), ContentType.APPLICATION_JSON, postElements, MMSUtils.JsonBlobType.ELEMENT_JSON);
 


### PR DESCRIPTION
While reviewing the 4.4.3 release branch a problem was identified with sending the overwrite parameter when the element being sent is a view, as doing so may remove generated view information. (see https://github.com/Open-MBEE/mdk/pull/197#discussion_r603084780)

This reverts the change for the time being to allow the release to go forward until we can work out how to better handle this situation.