### PR TITLE
Increment build number to 4.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=4.5.0
+version=4.5.1
 group=org.openmbee.mdk.magic
 descriptorFile=MDR_Plugin_Model_Development_Kit_91110_descriptor.xml
 magicdDrawGroupName=gov.nasa.jpl.cae.magicdraw.mdk


### PR DESCRIPTION
# Fixed

* Removed opaque disabling of SNI inside the MDK plugin startup script
* Fixed internal-source build process by backporting fixes from 5.x. This allows more seemless compilation of different versions of Cameo as well as adding more flexibility for building.
