### PR TITLE
fix commit parsing

### DIFF
--- a/src/main/java/gov/nasa/jpl/mbee/mdk/MDKPluginHelper.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/MDKPluginHelper.java
@@ -65,7 +65,7 @@ public class MDKPluginHelper {
 
     private void configureEnvironmentOptions() {
         EnvironmentOptions mdkOptions = Application.getInstance().getEnvironmentOptions();
-        mdkOptions.addGroup(new MDKEnvironmentOptionsGroup());
+        mdkOptions.addGroup(MDKEnvironmentOptionsGroup.getInstance());
     }
 
 

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/json/JacksonUtils.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/json/JacksonUtils.java
@@ -122,9 +122,9 @@ public class JacksonUtils {
         return parseJsonObject(parser);
     }
 
-    public static Map<String, Set<ObjectNode>> parseResponseIntoObjects(File responseFile, String expectedKey) throws IOException {
+    public static Map<String, List<ObjectNode>> parseResponseIntoObjects(File responseFile, String expectedKey) throws IOException {
         JsonToken current;
-        Map<String, Set<ObjectNode>> parsedResponseObjects = new HashMap<>();
+        Map<String, List<ObjectNode>> parsedResponseObjects = new HashMap<>();
         try(JsonParser jsonParser = JacksonUtils.getJsonFactory().createParser(responseFile)) {
             current = (jsonParser.getCurrentToken() == null ? jsonParser.nextToken() : jsonParser.getCurrentToken());
             if (current != JsonToken.START_OBJECT) {
@@ -155,8 +155,8 @@ public class JacksonUtils {
         return parsedResponseObjects;
     }
 
-    private static Set<ObjectNode> parseExpectedArray(JsonParser jsonParser, JsonToken current) throws IOException {
-        Set<ObjectNode> parsedObjects = new HashSet<>();
+    private static List<ObjectNode> parseExpectedArray(JsonParser jsonParser, JsonToken current) throws IOException {
+        List<ObjectNode> parsedObjects = new ArrayList<>();
         if (current != null) { // assumes the calling method has begun initial parsing stages
             current = jsonParser.nextToken();
             if(current.equals(JsonToken.START_ARRAY)) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/actions/CommitBranchAction.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/actions/CommitBranchAction.java
@@ -203,8 +203,8 @@ public class CommitBranchAction extends RuleViolationAction implements Annotatio
     }
 
     private ObjectNode findParentBranch(File responseFile, String parentBranchId) throws IOException {
-        Map<String, Set<ObjectNode>> parsedResponseObjects = JacksonUtils.parseResponseIntoObjects(responseFile, MDKConstants.REFS_NODE);
-        Set<ObjectNode> refObjects = parsedResponseObjects.get(MDKConstants.REFS_NODE);
+        Map<String, List<ObjectNode>> parsedResponseObjects = JacksonUtils.parseResponseIntoObjects(responseFile, MDKConstants.REFS_NODE);
+        List<ObjectNode> refObjects = parsedResponseObjects.get(MDKConstants.REFS_NODE);
 
         if(refObjects != null && !refObjects.isEmpty()) {
             for(ObjectNode refObjectNode : refObjects) {

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/mms/MMSDeltaProjectEventListenerAdapter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/mms/MMSDeltaProjectEventListenerAdapter.java
@@ -203,10 +203,10 @@ public class MMSDeltaProjectEventListenerAdapter extends ProjectEventListenerAda
 
         private void obtainAndParseCommits(Deque<String> commitIdDeque, Project project)
                 throws URISyntaxException, IOException, ServerException, GeneralSecurityException {
-            int limit = 100; // look at commits until it gets to lastSyncedCommitId
+            // look at commits until it gets to lastSyncedCommitId
             commitIdDeque.clear();
                 HashMap<String, String> uriBuilderParams = new HashMap<>();
-                uriBuilderParams.put("limit", Integer.toString(limit));
+                //uriBuilderParams.put("limit", Integer.toString(limit));
                 HttpRequestBase commitsRequest = MMSUtils.prepareEndpointBuilderBasicGet(MMSCommitsEndpoint.builder(), project)
                         .addParam(MMSEndpointBuilderConstants.URI_PROJECT_SUFFIX, Converters.getIProjectToIdConverter().apply(project.getPrimaryProject()))
                         .addParam(MMSEndpointBuilderConstants.URI_REF_SUFFIX, MDUtils.getBranchId(project))

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/mms/MMSDeltaProjectEventListenerAdapter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/mms/MMSDeltaProjectEventListenerAdapter.java
@@ -43,13 +43,16 @@ public class MMSDeltaProjectEventListenerAdapter extends ProjectEventListenerAda
             return;
         }
         projectClosed(project);
+        // no need to poll mms when it'll just do the whole thing at commit
+        /*
         getProjectMapping(project).setScheduledFuture(TaskRunner.scheduleWithProgressStatus(progressStatus -> {
             try {
                 getProjectMapping(project).update();
             } catch (URISyntaxException | IOException | ServerException | GeneralSecurityException e) {
                 e.printStackTrace();
             }
-        }, "MMS Fetch", false, TaskRunner.ThreadExecutionStrategy.POOLED, false, (r, ses) -> ses.scheduleAtFixedRate(r, 0, 1, TimeUnit.MINUTES)));
+        }, "MMS Fetch", false, TaskRunner.ThreadExecutionStrategy.POOLED, false, (r, ses) -> ses.scheduleAtFixedRate(r, 0, 60, TimeUnit.MINUTES)));
+        */
         if (MDKProjectOptions.getMbeeEnabled(project)) {
             MMSLoginAction.loginAction(project);
         }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/mms/MMSDeltaProjectEventListenerAdapter.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/sync/mms/MMSDeltaProjectEventListenerAdapter.java
@@ -248,7 +248,7 @@ public class MMSDeltaProjectEventListenerAdapter extends ProjectEventListenerAda
             if(commitObjects != null && !commitObjects.isEmpty()) {
                 Map<String, Integer> commitSizes = new HashMap<>();
                 for(ObjectNode jsonObject : commitObjects) {
-                    if(jsonObject.isArray() && jsonObject.size() > 0) {
+                    if(jsonObject.isObject() && jsonObject.size() > 0) {
                         validateJsonElementArray(jsonObject, lockedElementIds, commitSizes);
                     }
                     if (MDUtils.isDeveloperMode()) {
@@ -265,8 +265,8 @@ public class MMSDeltaProjectEventListenerAdapter extends ProjectEventListenerAda
             }
         }
 
-        private void validateJsonElementArray(JsonNode arrayNode, Set<String> lockedElementIds, Map<String, Integer> sizes) {
-            JsonNode sourceField = arrayNode.get(MDKConstants.SOURCE_FIELD);
+        private void validateJsonElementArray(JsonNode objectNode, Set<String> lockedElementIds, Map<String, Integer> sizes) {
+            JsonNode sourceField = objectNode.get(MDKConstants.SOURCE_FIELD);
             String commitSyncDirection = "";
             int size = 0;
             boolean isSyncingCommit = sourceField != null && sourceField.isTextual() && MDKConstants.MAGICDRAW_SOURCE_VALUE.equalsIgnoreCase(sourceField.asText());
@@ -279,7 +279,7 @@ public class MMSDeltaProjectEventListenerAdapter extends ProjectEventListenerAda
                 size = sizes.get(commitSyncDirection);
             }
             for (Map.Entry<String, Changelog.ChangeType> entry : CHANGE_MAPPING.entrySet()) {
-                JsonNode changesJsonArray = arrayNode.get(entry.getKey());
+                JsonNode changesJsonArray = objectNode.get(entry.getKey());
                 if (changesJsonArray == null || !changesJsonArray.isArray()) {
                     throw new IllegalStateException();
                 }

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/ElementValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/ElementValidator.java
@@ -144,8 +144,9 @@ public class ElementValidator implements RunnableWithProgress {
         // process the parsers against the lists, adding processed keys to processed sets in case of multiple returns
         for (File responseFile : serverElementFiles) {
             Map<String, List<ObjectNode>> parsedResponseObjects = JacksonUtils.parseResponseIntoObjects(responseFile, MDKConstants.ELEMENTS_NODE);
-            Set<ObjectNode> elementObjects = new HashSet<ObjectNode>(parsedResponseObjects.get(MDKConstants.ELEMENTS_NODE));
-            if(elementObjects != null && !elementObjects.isEmpty()) {
+            List<ObjectNode> elementObjectsList = parsedResponseObjects.get(MDKConstants.ELEMENTS_NODE);
+            if(elementObjectsList != null && !elementObjectsList.isEmpty()) {
+                Set<ObjectNode> elementObjects = new HashSet<>(elementObjectsList);
                 if(serverObjectsOnlyHasBins(elementObjects)) {
                     // solves edge case where first model validation incorrectly removes bins from project
                     removeServerObjectNodeUsingIdPrefix(elementObjects, MDKConstants.HOLDING_BIN_ID_PREFIX);

--- a/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/ElementValidator.java
+++ b/src/main/java/gov/nasa/jpl/mbee/mdk/mms/validation/ElementValidator.java
@@ -143,8 +143,8 @@ public class ElementValidator implements RunnableWithProgress {
     private void processServerElements(Map<String, Pair<Element, ObjectNode>> clientElementMap, Map<String, ObjectNode> serverElementMap) throws IOException {
         // process the parsers against the lists, adding processed keys to processed sets in case of multiple returns
         for (File responseFile : serverElementFiles) {
-            Map<String, Set<ObjectNode>> parsedResponseObjects = JacksonUtils.parseResponseIntoObjects(responseFile, MDKConstants.ELEMENTS_NODE);
-            Set<ObjectNode> elementObjects = parsedResponseObjects.get(MDKConstants.ELEMENTS_NODE);
+            Map<String, List<ObjectNode>> parsedResponseObjects = JacksonUtils.parseResponseIntoObjects(responseFile, MDKConstants.ELEMENTS_NODE);
+            Set<ObjectNode> elementObjects = new HashSet<ObjectNode>(parsedResponseObjects.get(MDKConstants.ELEMENTS_NODE));
             if(elementObjects != null && !elementObjects.isEmpty()) {
                 if(serverObjectsOnlyHasBins(elementObjects)) {
                     // solves edge case where first model validation incorrectly removes bins from project


### PR DESCRIPTION
previously there were various issues with commit parsing:
- mms commit polling and commits check during twc commit are only getting the last commit, missing any commits made between the polling
- it didn't actually get commits as it was checking if commit objects were arrays
- the commit array was gotten as a set which removed commit order
this fixes that so it gets all missing mms commits at twc commit time, also gets it as a list instead of set so the order is correct
also fixes environment options logjson using singleton